### PR TITLE
Wgs/add pytorch

### DIFF
--- a/.github/workflows/_linux-test.yml
+++ b/.github/workflows/_linux-test.yml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
     runs-on: tps-pytorch-ci
     env:
-      TORCH_CUDA_ARCH_LIST: "Volta;7.0;7.5;8.0;8.6"
       CI: "true"
       DEBUG: 0
       TEST_CONFIG: ${{ matrix.config }}

--- a/.github/workflows/pytorch_nv.yml
+++ b/.github/workflows/pytorch_nv.yml
@@ -2,9 +2,6 @@ name: pytorch ci
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - 'wgs/*'
 
 env:
   PVC_PATH: '/nvme/share/share/github/cibuild/${{ github.repository }}'
@@ -13,6 +10,8 @@ env:
   CI_IMAGE: "registry.sensetime.com/parrots/ci:linux-bionic-cuda11.7-cudnn8-py3-gcc7"
   BUILD_ENVIRONMENT: "linux-bionic-cuda11.7-py3.10-gcc7"
   PYTORCH_COMMIT: "461f088"
+  TORCH_CUDA_ARCH_LIST: "Volta;7.0;7.5;8.0;8.6"
+
 
 jobs:
   Checkout:
@@ -39,8 +38,6 @@ jobs:
     needs: [Checkout]
     timeout-minutes: 240
     env:
-      TORCH_CUDA_ARCH_LIST: "Volta;7.0;7.5;8.0;8.6"
-      GPU_NUM: 1
       DEBUG: 0
     steps:
       - name: build


### PR DESCRIPTION
目标：在dipu_poc中搭建一套基于NV的pytorch ci
过程：经过从slurm ，到sensecore(存在bug)，到实验室A100机器，最后落实在实验室一台v100机器上，使用docker镜像去跑pytorch ci
结果：参考pytorch 源码中dockerflie，构建需要的CI镜像registry.sensetime.com/parrots/ci:linux-bionic-cuda11.7-cudnn8-py3-gcc7，实现docker 指定GPU来跑CI任务
存在问题：部分配置的测试需要A100机器，以及存在rpc相关的报错，后续需要研发看下是否能注释掉(CI部分可参考https://github.com/pytorch/pytorch/tree/main/.github/workflows中，其中包含多种测试，选取了基于ubuntu的linux-bionic-cuda11.7-cudnn8-py3-gcc7 去进行ci验证)

1.目前改为手动触发才会运行pytorch ci
2.pytorch ci运行的ci 基于PYTORCH_COMMIT指定的代码，后续更新也需要同时确认下ci及ci镜像是否需要升级
3.构建使用pytorch 源码中.ci/pytorch/build.sh；测试使用.ci/pytorch/test.sh ,通过test-matrix指定不同的测试，可调整test.sh 及其相关的测试shell去调整测试用例