### PR TITLE
fix: error in adaptor declaration

### DIFF
--- a/torch_dipu/csrc_dipu/vendor/camb/diopi_adapter.hpp
+++ b/torch_dipu/csrc_dipu/vendor/camb/diopi_adapter.hpp
@@ -2199,14 +2199,14 @@ inline diopiError_t diopiIndexFill(diopiContextHandle_t ctx, diopiTensorHandle_t
     return ::diopiIndexFill(ctx, out, input, dim, index, value);
 }
 
-inline diopiError_t diopiIndexFillInpScalar(diopiContextHandle_t ctx, diopiConstTensorHandle_t input, int64_t dim, diopiConstTensorHandle_t index, const diopiScalar_t* value) {
+inline diopiError_t diopiIndexFillInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t input, int64_t dim, diopiConstTensorHandle_t index, const diopiScalar_t* value) {
 
 
 
     return ::diopiIndexFillInpScalar(ctx, input, dim, index, value);
 }
 
-inline diopiError_t diopiIndexFillInp(diopiContextHandle_t ctx, diopiConstTensorHandle_t input, int64_t dim, diopiConstTensorHandle_t index, diopiConstTensorHandle_t value) {
+inline diopiError_t diopiIndexFillInp(diopiContextHandle_t ctx, diopiTensorHandle_t input, int64_t dim, diopiConstTensorHandle_t index, diopiConstTensorHandle_t value) {
 
 
 


### PR DESCRIPTION
diopi更新了functions.h
DIOPI_API diopiError_t diopiIndexFillInpScalar(diopiContextHandle_t ctx, diopiTensorHandle_t input, int64_t dim, diopiConstTensorHandle_t index,
                                               const diopiScalar_t* value);
DIOPI_API diopiError_t diopiIndexFillInp(diopiContextHandle_t ctx, diopiTensorHandle_t input, int64_t dim, diopiConstTensorHandle_t index,
                                         diopiConstTensorHandle_t value);
此处也需要对应更新一下