### PR TITLE
add diopi main ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
     env:
       MLU_REQUESTS: 1
     steps:
-      - name: Build diopi-poc
+      - name: Build dipu-poc
         run: |
           ssh ${CLUSTER_CAMB} """
           set -e
@@ -137,7 +137,7 @@ jobs:
     env:
       MLU_REQUESTS: 1
     steps:
-      - name: Build diopi-poc diopi-main
+      - name: Build dipu-poc diopi-main
         run: |
           ssh ${CLUSTER_CAMB} """
           set -e
@@ -209,21 +209,20 @@ jobs:
           else
           git checkout ${{ github.sha }} &&  git merge --no-edit main
           fi
-          cd ${NV_PVC_PATH}/${GITHUB_RUN_NUMBER}/dipu_poc
+          cd ${NV_PVC_PATH}/${GITHUB_RUN_NUMBER} && cp -R dipu_poc dipu_poc_diopi
+          cd ${NV_PVC_PATH}/${GITHUB_RUN_NUMBER}/dipu_poc_diopi/third_party && rm -rf DIOPI && git clone https://github.com/DeepLink-org/DIOPI.git
+          cd ${NV_PVC_PATH}/${GITHUB_RUN_NUMBER}/dipu_poc && rm -rf third_party/DIOPI && git submodule update --init --recursive
           rm -rf SMART && git clone -b ywt/one_iter_tool_for_mmcv_2.0 https://github.com/ParrotsDL/SMART.git
           rm -rf mmpretrain && git clone -b ${MMPRETRAIN_VERSION} https://github.com/DeepLink-org/mmpretrain.git
           rm -rf mmcv && git clone -b ${MMCV_VERSION} https://github.com/open-mmlab/mmcv.git
           rm -rf mmengine && git clone -b ${MMENGINE_VERSION} https://github.com/open-mmlab/mmengine.git
-          cd ${NV_PVC_PATH}/${GITHUB_RUN_NUMBER} && cp -R dipu_poc dipu_poc_diopi
-          cd ${NV_PVC_PATH}/${GITHUB_RUN_NUMBER}/dipu_poc && rm -rf third_party/DIOPI && git submodule update --init --recursive
-          cd ${NV_PVC_PATH}/${GITHUB_RUN_NUMBER}/dipu_poc_diopi/third_party && rm -rf DIOPI && git clone https://github.com/DeepLink-org/DIOPI.git
 
   Build-POC-Cuda:
     name: Build diopi_poc cuda
     needs: [Clone]
     runs-on: tps-pytorch-ci
     steps:
-      - name: Build diopi-poc
+      - name: Build dipu-poc
         run: |
           set -e
           cd ${NV_PVC_PATH}/${GITHUB_RUN_NUMBER} && rm -rf ${GITHUB_JOB} && cp -R dipu_poc ${GITHUB_JOB}  && cd ${GITHUB_JOB}
@@ -248,7 +247,7 @@ jobs:
     needs: [Clone]
     runs-on: tps-pytorch-ci
     steps:
-      - name: Build diopi-poc diopi-main
+      - name: Build dipu-poc diopi-main
         run: |
           set -e
           cd ${NV_PVC_PATH}/${GITHUB_RUN_NUMBER} && rm -rf ${GITHUB_JOB} && cp -R dipu_poc_diopi ${GITHUB_JOB}  && cd ${GITHUB_JOB}


### PR DESCRIPTION
分别在nv和camb上，同时支持diopi submodule和diopi main的build和test
分支的CI任务见：https://github.com/DeepLink-org/dipu_poc/actions/runs/5186897787/jobs/9348667321