### PR TITLE
add memory checker

### DIFF
--- a/tests/test_ops/have_bug/test_resnet.py
+++ b/tests/test_ops/have_bug/test_resnet.py
@@ -186,7 +186,7 @@ def test_resnetmy():
     m = _resnetmyself().to(device)
     # print(m)
 
-    optimizer = optim.SGD(m.parameters(), lr=0.001, momentum=0.9)
+    optimizer = optim.SGD(m.parameters(), lr=0.001, momentum=0.9, foreach=False)
 
     in1 = torch.range(1, 602112).reshape(1, 3, 448, 448).to(device)
     # in1 = torch.range(1, 200704).reshape(1, 64, 56, 56).to(device)

--- a/torch_dipu/__init__.py
+++ b/torch_dipu/__init__.py
@@ -3,6 +3,10 @@ import os
 os.environ['CUDA_LAUNCH_BLOCKING'] = '1'
 os.environ['MLU_INVOKE_BLOCKING'] = '1'
 os.environ['TORCH_SHOW_CPP_STACKTRACES'] = '1'
+# os.environ['DIPU_MEM_CHECK'] = '1'
+# os.environ['DIPU_MEM_CHECK_MAX_BLOCK'] = '10000'
+# os.environ['DIPU_MEM_CHECK_LOG_INTERVAL'] = '1000'
+# os.environ['DIPU_MEM_CHECK_ENABLE_BACKTRACE'] = '1'
 
 import torch
 from typing import (Tuple, List, Union, Sequence)

--- a/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -16,6 +16,7 @@ file(GLOB RT_SRC_FILES runtime/core/guardimpl/*.cpp
     runtime/core/allocator.cpp
     runtime/core/DIPU*.cpp
     runtime/core/device.cpp
+    runtime/core/MemChecker.cpp
     runtime/distributed/*.cpp
 )
 

--- a/torch_dipu/csrc_dipu/aten/ops/ResizeKernel.cpp
+++ b/torch_dipu/csrc_dipu/aten/ops/ResizeKernel.cpp
@@ -8,7 +8,7 @@
 
 #include <csrc_dipu/aten/DIPUATenFunctions.h>
 #include <csrc_dipu/runtime/rthelper.h>
-
+#include <csrc_dipu/runtime/core/MemChecker.h>
 
 using c10::device_or_default;
 using c10::layout_or_default;
@@ -35,6 +35,8 @@ namespace dipu::native {
     size_t nbytes = std::min(storage->nbytes(), newsize_bytes);
     at::DataPtr data = allocator->allocate(newsize_bytes);  // alloc new 
     if (storage->data_ptr()) {   // copy old to new
+      MemChecker::instance().check(data.get());
+      MemChecker::instance().check(storage->data());
       dipu::devapis::memCopyD2DAsync(stream.rawstream(), nbytes, device, data.get(),
             device, storage->data());
     }

--- a/torch_dipu/csrc_dipu/diopirt/diopirt_impl.h
+++ b/torch_dipu/csrc_dipu/diopirt/diopirt_impl.h
@@ -16,7 +16,6 @@ using deviceStream_t = dipu::deviceStream_t;
 
 extern "C" {
 struct diopiContext {
-    // TODO(caikun): use dipu stream? can only use device stream?
     deviceStream_t stream;
     // 1. use arrays to hold tensor that avoid tensor deleting when leaving scope
     // 2. The address of each array must be fixed, so use list instead of vector

--- a/torch_dipu/csrc_dipu/runtime/core/MemChecker.cpp
+++ b/torch_dipu/csrc_dipu/runtime/core/MemChecker.cpp
@@ -1,0 +1,156 @@
+// Copyright (c) 2023, DeepLink.
+#include "MemChecker.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include <c10/util/Exception.h>
+#include <c10/util/Backtrace.h>
+
+namespace dipu {
+
+static const int32_t DEFAULT_MAX_BLOCK_NUM = 10000;
+static const int32_t DEFAULT_LOG_INTERVAL = 1000;
+
+MemChecker::~MemChecker() {
+  if (!enable()) {
+    return;
+  }
+
+  if (!blocks_.empty()) {
+    std::cout << "dipu memory checker: there maybe exist memory leak. "
+      << blocks_.size() << " blocks not released." << std::endl;
+    for (const auto &kv : blocks_) {
+      std::cout << "key: " << kv.first << ", ptr: " << kv.second.first << ", trace: " << kv.second.second << std::endl;
+    }
+  }
+  std::cout << "dipu memory checker: going to destruction. " << current_state() << std::endl;
+}
+
+MemChecker& MemChecker::instance() {
+  static MemChecker checker;
+  return checker;
+}
+
+bool MemChecker::enable() {
+  static bool enable = (std::getenv("DIPU_MEM_CHECK") != nullptr);
+  return enable;
+}
+
+bool MemChecker::enable_backtrace() {
+  static bool enable_trace = (std::getenv("DIPU_MEM_CHECK_ENABLE_BACKTRACE") != nullptr);
+  return enable_trace;
+}
+
+int32_t MemChecker::max_block_num() {
+  static int32_t max_block = []() -> int32_t {
+    const char* str = std::getenv("DIPU_MEM_CHECK_MAX_BLOCK");
+    if (str == nullptr) {
+      return DEFAULT_MAX_BLOCK_NUM;
+    }
+    return std::stoi(str);
+  }();
+
+  return max_block;
+}
+
+int32_t MemChecker::log_interval() {
+  static int32_t interval = []() -> int32_t {
+    const char* str = std::getenv("DIPU_MEM_CHECK_LOG_INTERVAL");
+    if (str == nullptr) {
+      return DEFAULT_LOG_INTERVAL;
+    }
+    return std::stoi(str);
+  }();
+
+  return interval;
+}
+
+std::string MemChecker::current_state() const {
+  std::stringstream stream;
+  stream << "current block num = " <<  blocks_.size()
+    << ", total_size = " << (total_size_ >> 20) << "MB"
+    << ", insert count = " << insert_cnt_
+    << ", max block num = " << max_block_num()
+    << ", log interval = " << log_interval();
+  return stream.str();
+}
+
+void MemChecker::insert(const void* ptr, size_t size) {
+  if (!enable() || ptr == nullptr) {
+    return;
+  }
+
+  bool may_leak = false;
+  bool print_log = false;
+  std::string state;
+  {
+    std::lock_guard<std::mutex> lck(mtx_);
+    blocks_[ptr] = std::make_pair(size, enable_backtrace() ? c10::get_backtrace() : "");
+    total_size_ += static_cast<int64_t>(size);
+    ++insert_cnt_;
+
+    if (blocks_.size() > max_block_num()) {
+      may_leak = true;
+    } else if (insert_cnt_ % log_interval() == 0) {
+      print_log = true;
+    }
+
+    if (may_leak || print_log) {
+      state = current_state();
+    }
+  }
+
+  if (may_leak) {
+    std::cout << "dipu memory checker: there may be memory leak. " << state << std::endl;
+  } else if (print_log) {
+    std::cout << "dipu memory checker: " << state << std::endl;
+  }
+}
+
+void MemChecker::erase(const void* ptr) {
+  if (!enable() || ptr == nullptr) {
+    return;
+  }
+
+  bool found = true;
+  {
+    std::lock_guard<std::mutex> lck(mtx_);
+    auto iter = blocks_.find(ptr);
+    if (iter == blocks_.end()) {
+      found = false;
+    } else {
+      total_size_ -= static_cast<int64_t>(iter->second.first);
+      blocks_.erase(iter);
+    }
+  }
+
+  if (!found) {
+    std::cout << "dipu memory checker: not found point address going to free, ptr = " << ptr << std::endl;
+  }
+}
+
+void MemChecker::check(const at::Tensor &input) {
+  const void *ptr = input.unsafeGetTensorImpl()->unsafe_storage().data();
+  check(ptr);
+}
+
+void MemChecker::check(const void* ptr) {
+  if (!enable()) {
+    return;
+  }
+
+  bool found = true;
+  {
+    std::lock_guard<std::mutex> lck(mtx_);
+    found = (blocks_.find(ptr) != blocks_.end());
+  }
+
+  if (!found) {
+    std::cout << "dipu memory checker: not found point address when check, ptr = " << ptr << std::endl;
+  }
+}
+
+}  // namespace dipu

--- a/torch_dipu/csrc_dipu/runtime/core/MemChecker.h
+++ b/torch_dipu/csrc_dipu/runtime/core/MemChecker.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2023, DeepLink.
+#pragma once
+
+#include <stdint.h>
+
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include <ATen/Tensor.h>
+
+namespace dipu {
+
+class MemChecker final {
+public:
+  static MemChecker& instance();
+  static bool enable();
+  static bool enable_backtrace();
+  static int32_t max_block_num();
+  static int32_t log_interval();
+
+  void insert(const void* ptr, size_t size);
+  void erase(const void* ptr);
+  void check(const at::Tensor& input);
+  void check(const void* ptr);
+  ~MemChecker();
+
+private:
+  std::string current_state() const;
+
+private:
+  std::mutex mtx_;
+  std::unordered_map<const void*, std::pair<size_t, std::string>> blocks_;
+  int64_t total_size_ = 0;
+  int64_t insert_cnt_ = 0;
+};
+
+}  // namespace dipu

--- a/torch_dipu/csrc_dipu/runtime/core/allocator.h
+++ b/torch_dipu/csrc_dipu/runtime/core/allocator.h
@@ -6,6 +6,7 @@
 
 #include <csrc_dipu/common.h>
 #include <csrc_dipu/runtime/device/deviceapis.h>
+#include <csrc_dipu/runtime/core/MemChecker.h>
 
 namespace dipu {
 
@@ -13,6 +14,7 @@ static std::mutex dipu_mutex;
 
 static void DIPUDeleter(void* ptr) {
   if (ptr) {
+    MemChecker::instance().erase(ptr);
     devapis::freeDevice(ptr);
     ptr = nullptr;
   }
@@ -32,6 +34,7 @@ protected:
     std::lock_guard<std::mutex> lock(dipu_mutex);
     void* data = nullptr;
     devapis::mallocDevice(&data, nbytes);
+    MemChecker::instance().insert(data, nbytes);
     return {data, data, &DIPUDeleter, c10::Device(dipu::DIPU_DEVICE_TYPE, device_index)};
   }
 };


### PR DESCRIPTION
增加memory checker
1. 支持memory leak检查，检测出leak后支持打印堆栈
2. 支持对使用tensor是否被释放的检查，主要针对pointpillars出现的cnMemcpyDtoDAsync invalid address的问题，可以看看这个存储是否被删除掉了
3. 定期打印统计信息(总共申请的存储大小)