### PR TITLE
new tensor when arg is torch.storage

### DIFF
--- a/tests/test_ops/archived/test_tensor_new.py
+++ b/tests/test_ops/archived/test_tensor_new.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2023, DeepLink.
+
+import torch
+import torch_dipu
+
+def test_tensor_new(devicestr):
+    device = torch.device(devicestr)
+    x = torch.randn(10, 10).to(device)
+    y = torch.randn(2, 2).to(device)
+    z = y.new(x.storage())
+    assert torch.allclose(x, z.reshape(10, 10))
+
+test_tensor_new("cpu")
+#test_tensor_new("dipu")

--- a/torch_dipu/__init__.py
+++ b/torch_dipu/__init__.py
@@ -80,6 +80,12 @@ def apply_tensor_method_patch():
             return self.new_empty(size, device = device)
         if isinstance(arg, Tensor):
             return self.new_tensor(arg, device = device) 
+        elif isinstance(arg, torch.storage.TypedStorage) or isinstance(arg, torch.storage.UntypedStorage):
+            if (isinstance(device, torch.device) and device.type != 'cpu') or \
+                isinstance(device, str) and torch.device(device).type != 'cpu':
+                print(f"torch.Tensor.new_tensor(storage: torch.storage) is not supported on out-of-tree device")
+
+            return self.new_tensor(arg, device = device)
         elif isinstance(arg, Tuple) or isinstance(arg, torch.Size) or isinstance(arg, List):
             return self.new_tensor(arg, device = device) 
         else:


### PR DESCRIPTION
dataloader num_workers参数大于0时，加载dipu跑模型会出错，错误如下

```python
Traceback (most recent call last):
  File "tools/train.py", line 163, in <module>
    main()
  File "tools/train.py", line 159, in main
    runner.train()
  File "/home/caikun/code/models/resnet50/mmengine/mmengine/runner/runner.py", line 1721, in train
    model = self.train_loop.run()  # type: ignore
  File "/home/caikun/code/models/resnet50/mmengine/mmengine/runner/loops.py", line 96, in run
    self.run_epoch()
  File "/home/caikun/code/models/resnet50/mmengine/mmengine/runner/loops.py", line 111, in run_epoch
    for idx, data_batch in enumerate(self.dataloader):
  File "/home/caikun/code/pytorch/torch/utils/data/dataloader.py", line 634, in __next__
    data = self._next_data()
  File "/home/caikun/code/pytorch/torch/utils/data/dataloader.py", line 1346, in _next_data
    return self._process_data(data)
  File "/home/caikun/code/pytorch/torch/utils/data/dataloader.py", line 1372, in _process_data
    data.reraise()
  File "/home/caikun/code/pytorch/torch/_utils.py", line 644, in reraise
    raise exception
AttributeError: Caught AttributeError in DataLoader worker process 0.
Original Traceback (most recent call last):
  File "/home/caikun/code/pytorch/torch/utils/data/_utils/worker.py", line 308, in _worker_loop
    data = fetcher.fetch(index)
  File "/home/caikun/code/pytorch/torch/utils/data/_utils/fetch.py", line 54, in fetch
    return self.collate_fn(data)
  File "/home/caikun/code/models/resnet50/mmengine/mmengine/dataset/utils.py", line 160, in default_collate
    return data_item_type({
  File "/home/caikun/code/models/resnet50/mmengine/mmengine/dataset/utils.py", line 161, in <dictcomp>
    key: default_collate([d[key] for d in data_batch])
  File "/home/caikun/code/models/resnet50/mmengine/mmengine/dataset/utils.py", line 165, in default_collate
    return torch_default_collate(data_batch)
  File "/home/caikun/code/pytorch/torch/utils/data/_utils/collate.py", line 264, in default_collate
    return collate(batch, collate_fn_map=default_collate_fn_map)
  File "/home/caikun/code/pytorch/torch/utils/data/_utils/collate.py", line 119, in collate
    return collate_fn_map[elem_type](batch, collate_fn_map=collate_fn_map)
  File "/home/caikun/code/pytorch/torch/utils/data/_utils/collate.py", line 161, in collate_tensor_fn
    out = elem.new(storage).resize_(len(batch), *list(elem.size()))
AttributeError: 'NoneType' object has no attribute 'resize_'
``` 

原因：_legacy_new_mocker没有考虑arg为 torch.storage的情况，现在加上对torch.storage的支持