### PR TITLE
feature: ywt/pass-empty-savestd-and-savemean-when-no-grad-or-testing for-bn

### DIFF
--- a/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -157,9 +157,8 @@
     auto out0 = at::empty_like(input);
     auto options = input.options().dtype(at::kFloat);
     at::Tensor out1, out2;
-    bool compute_stats = (input.requires_grad() || (weight.has_value() && weight.value().requires_grad()) || (bias.has_value() && bias.value().requires_grad()));
-    if (!training || !compute_stats) {
-        // do not require save_mean/save_invstd when no_grad or test mode
+    if (!training) {
+        // do not require save_mean/save_invstd when in test mode
         out1 = at::empty({0}, options);
         out2 = at::empty({0}, options);
     } else {


### PR DESCRIPTION
When in `no_grad` mode or testing mode, there is no need to require and pass savestd and savemean to diopi funcs, which is resource-wasting and causes autocompare error in bn
This pr fix that issue.