### PR TITLE
fix: dumpArg-print-real-tensor-param

### DIFF
--- a/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
+++ b/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
@@ -77,9 +77,9 @@ template<>
 std::string dumpArg(const at::Tensor& tensor) {
     std::stringstream stream;
     if (tensor.defined()) {
-        stream << "numel:" << tensor.numel() << ",sizes:" << tensor.sizes() << ", stride:" << tensor.strides() << ",is_view:" << tensor.is_view() << "," << "dtype=" << tensor.dtype()
-        << ", device=" << tensor.device() << ", layout=" << tensor.layout() << ", requires_grad=" << (tensor.requires_grad() ? "true" : "false") << ", pinned_memory=" << (tensor.is_pinned() ? "true" : "false") 
-        << ", memory_format="  << tensor.suggest_memory_format() << ", data_ptr:" << tensor.data_ptr();
+        stream << "numel: " << tensor.numel() << ",sizes: " << tensor.sizes() << ", stride: " << tensor.strides() << ", is_view: " << tensor.is_view() << ", dtype: " << tensor.dtype()
+        << ", device:" << tensor.device() << ", layout:" << tensor.layout() << ", requires_grad: " << (tensor.requires_grad() ? "true" : "false") << ", pinned_memory: " << (tensor.is_pinned() ? "true" : "false") 
+        << ", memory_format: "  << tensor.suggest_memory_format() << ",  data_ptr: " << tensor.data_ptr();
         if (dumpOpArgLevel() > 2) {
             stream << std::endl << tensor;
         }


### PR DESCRIPTION
`tensor.options()` is the options when creating the tensors. The param of tensor like `requires_grad` may be changed after tensor creation, this pr fixes that issue.