### PR TITLE
[dipu] Add .clang-tidy

### DIFF
--- a/dipu/.clang-tidy
+++ b/dipu/.clang-tidy
@@ -28,7 +28,7 @@ Checks: '
   performance-*,
   readability-*,
   -readability-identifier-length,
-  -readability-identifier-naming,
+  -readability-identifier-naming,  # TODO(issues/446): naming convention
   -readability-qualified-auto,
   -readability-static-accessed-through-instance'
 AnalyzeTemporaryDtors: false

--- a/dipu/.clang-tidy
+++ b/dipu/.clang-tidy
@@ -1,0 +1,99 @@
+---
+Checks: '
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-reserved-identifier,
+  clang-analyzer-*,
+  clang-diagnostic-*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-special-member-functions,
+  google-*,
+  -google-*googletest*,
+  hicpp-avoid-goto,
+  hicpp-exception-baseclass,
+  misc-unused-alias-decls,
+  misc-unused-using-decls,
+  modernize-*,
+  -modernize-use-trailing-return-type,
+  performance-*,
+  readability-*,
+  -readability-identifier-length,
+  -readability-identifier-naming,
+  -readability-qualified-auto,
+  -readability-static-accessed-through-instance'
+AnalyzeTemporaryDtors: false
+FormatStyle: file
+HeaderFilterRegex: '.*'
+CheckOptions:
+  - key:   cppcoreguidelines-avoid-do-while.IgnoreMacros
+    value: true
+  - key:   cppcoreguidelines-narrowing-conversions.IgnoreConversionFromTypes
+    value: 'size_t;ptrdiff_t;size_type;difference_type'
+  - key:   readability-function-cognitive-complexity.IgnoreMacros
+    value: true
+  - key:   readability-implicit-bool-conversion.AllowIntegerConditions
+    value: true
+  - key:   readability-implicit-bool-conversion.AllowPointerConditions
+    value: true
+# --- Google's naming convention BEGIN ---
+# modified part is marked as comment
+  - key:   readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key:   readability-identifier-naming.ClassMemberCase
+    value: lower_case
+  - key:   readability-identifier-naming.ConstexprVariableCase
+    value: CamelCase
+  - key:   readability-identifier-naming.ConstexprVariablePrefix
+    value: k
+  - key:   readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key:   readability-identifier-naming.EnumConstantCase
+    value: CamelCase
+  - key:   readability-identifier-naming.EnumConstantPrefix
+    value: k
+  - key:   readability-identifier-naming.FunctionCase
+    value: CamelCase
+  - key:   readability-identifier-naming.GlobalConstantCase
+    value: CamelCase
+  - key:   readability-identifier-naming.GlobalConstantPrefix
+    value: k
+  - key:   readability-identifier-naming.StaticConstantCase
+    value: CamelCase
+  - key:   readability-identifier-naming.StaticConstantPrefix
+    value: k
+  - key:   readability-identifier-naming.StaticVariableCase
+    value: lower_case
+  - key:   readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
+  - key:   readability-identifier-naming.MacroDefinitionIgnoredRegexp
+    value: '^[A-Z]+(_[A-Z]+)*_$'
+  - key:   readability-identifier-naming.MemberCase
+    value: lower_case
+  - key:   readability-identifier-naming.PrivateMemberSuffix
+    value: _
+  - key:   readability-identifier-naming.PublicMemberSuffix
+    value: ''
+  - key:   readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key:   readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key:   readability-identifier-naming.TypeAliasCase
+    value: CamelCase
+  - key:   readability-identifier-naming.TypedefCase
+    value: CamelCase
+  - key:   readability-identifier-naming.VariableCase
+    value: lower_case
+  - key:   readability-identifier-naming.IgnoreMainLikeFunctions
+    value: 1
+# --- Google's naming convention END   ---
+...

--- a/dipu/.clangd
+++ b/dipu/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Remove: -fabi*

--- a/dipu/third_party/CMakeLists.txt
+++ b/dipu/third_party/CMakeLists.txt
@@ -112,8 +112,8 @@ ExternalProject_Add_StepDependencies(kineto_internal build kineto_internal-confi
 #-----------------------------------------------------------------------------------------------
 add_library(kineto_lib STATIC IMPORTED)
 add_library(kineto_fmt STATIC IMPORTED)
-add_dependencies(kineto_lib kineto_internal-build)
-add_dependencies(kineto_fmt kineto_internal-build)
+add_library(kineto INTERFACE)
+add_dependencies(kineto kineto_internal-build)
 set_target_properties(
   kineto_lib PROPERTIES IMPORTED_LOCATION
                         "${KINETO_BUILD_PATH}/libkineto.a")

--- a/dipu/third_party/CMakeLists.txt
+++ b/dipu/third_party/CMakeLists.txt
@@ -88,48 +88,15 @@ if(NOT WITH_DIOPI_LIBRARY STREQUAL "DISABLE")
 endif()
 
 #-------------------------add kineto as an external project ------------------------------------
-#-------------------------use the local submodule(without download)-----------------------------
-set(KINETO_BUILD_TARGET "kineto_internal-build")
-set(KINETO_SRC_PATH "${CMAKE_CURRENT_SOURCE_DIR}/kineto")
-set(KINETO_BUILD_PATH "${KINETO_SRC_PATH}/build")
-ExternalProject_Add(kineto_internal
-                    PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/kineto/"
-                    SOURCE_DIR ${KINETO_SRC_PATH}
-                    SOURCE_SUBDIR libkineto
-                    BINARY_DIR ${KINETO_BUILD_PATH}
-                    DOWNLOAD_COMMAND ""
-                    CMAKE_ARGS "-DKINETO_BUILD_TESTS=OFF"
-                               "-DKINETO_USE_DEVICE_ACTIVITY=ON"
-                               "-DKINETO_COMPILED_WITH_CXX11_ABI=${DIPU_COMPILED_WITH_CXX11_ABI}"
-                               "-DCMAKE_EXPORT_COMPILE_COMMANDS=${CMAKE_EXPORT_COMPILE_COMMANDS}"
-                    BUILD_BYPRODUCTS "${KINETO_BUILD_PATH}/fmt/libfmt.a"
-                                     "${KINETO_BUILD_PATH}/libkineto.a"
-                    INSTALL_COMMAND cmake -E echo "Skipping install step for kineto_internal."
-)
-## The following code is a work around to avoid make file to run multiple externalProject-build when using make -j N
-ExternalProject_Add_StepTargets(kineto_internal configure build)
-ExternalProject_Add_StepDependencies(kineto_internal build kineto_internal-configure)
-#-----------------------------------------------------------------------------------------------
-add_library(kineto_lib STATIC IMPORTED)
-add_library(kineto_fmt STATIC IMPORTED)
-add_library(kineto INTERFACE)
-add_dependencies(kineto kineto_internal-build)
-set_target_properties(
-  kineto_lib PROPERTIES IMPORTED_LOCATION
-                        "${KINETO_BUILD_PATH}/libkineto.a")
-set_target_properties(
-  kineto_fmt PROPERTIES IMPORTED_LOCATION
-                        "${KINETO_BUILD_PATH}/fmt/libfmt.a")
-target_include_directories(kineto_fmt SYSTEM INTERFACE
-  ${KINETO_SRC_PATH}/libkineto/third_party/fmt/include
-)
-target_include_directories(kineto_lib SYSTEM INTERFACE
-  ${KINETO_SRC_PATH}/libkineto/include
-  ${KINETO_SRC_PATH}/libkineto/src
-  ${KINETO_SRC_PATH}/libkineto/third_party/fmt/include
-)
-add_library(kineto INTERFACE)
-target_link_libraries(kineto INTERFACE kineto_fmt kineto_lib)
-target_compile_definitions(kineto INTERFACE USE_KINETO)
-#-----------------------------------------------------------------------------------------------
 
+include(FetchContent)
+FetchContent_Declare(
+  kineto
+  URL           "${CMAKE_CURRENT_SOURCE_DIR}/kineto"
+  SOURCE_SUBDIR libkineto
+  SYSTEM)
+set(KINETO_BUILD_TESTS OFF CACHE INTERNAL "turn off tests")
+set(KINETO_USE_DEVICE_ACTIVITY ON CACHE INTERNAL "enable device activity")
+set(KINETO_COMPILED_WITH_CXX11_ABI "${DIPU_COMPILED_WITH_CXX11_ABI}" CACHE INTERNAL "keep abi settings")
+
+FetchContent_MakeAvailable(kineto)

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -80,7 +80,9 @@ add_library(${DIPU_LIB} SHARED ${SOURCE_FILES})
 
 # link
 target_link_libraries(${DIPU_LIB} ${DIPU_VENDOR_LIB})
-target_link_libraries(${DIPU_LIB} kineto)
+target_link_libraries(${DIPU_LIB} kineto kineto_base)
+target_compile_definitions(${DIPU_LIB} PRIVATE USE_KINETO)
+
 target_link_libraries(${DIPU_LIB} diopi_impl)
 # target_link_libraries(${DIPU_LIB} -Wl,--no-as-needed diopi_impl -Wl,--as-needed)
 


### PR DESCRIPTION
1. 为 DIPU 仓库添加一个 `.clang-tidy` 文件，待问题修正之后，再修改 CI 等配置
2. 重构 (简化) 了 kineto 的引入方式，尝试修复 libfmt 的编译时机的问题