### PR TITLE
[both] Upgrade to clang 17 to use InheritParentConfig

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           style: file
           tidy-checks: '-*' # disable clang tidy at this stage
+          version: 17
       - name: Fail test
         if: steps.linter.outputs.checks-failed > 0
         run: echo "Some files failed the linting checks!" && exit 1

--- a/dipu/torch_dipu/csrc_dipu/diopirt/diopirt_impl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/diopirt/diopirt_impl.cpp
@@ -88,26 +88,26 @@ DIOPI_RT_API diopiError_t diopiGetTensorElemSize(diopiConstTensorHandle_t pth,
 }
 
 DIOPI_RT_API diopiError_t diopiGetTensorStoragePtr(diopiConstTensorHandle_t pth,
-                                                   void** pStoragePtr) {
-  *pStoragePtr = (reinterpret_cast<const at::Tensor*>(pth))->storage().data();
+                                                   void **pStoragePtr) {
+  *pStoragePtr = (reinterpret_cast<const at::Tensor *>(pth))->storage().data();
   return diopiSuccess;
 }
 
-DIOPI_RT_API diopiError_t diopiGetTensorStorageOffset(
-    diopiConstTensorHandle_t pth, int64_t* pOffset) {
-  *pOffset = (reinterpret_cast<const at::Tensor*>(pth))->storage_offset();
+DIOPI_RT_API diopiError_t
+diopiGetTensorStorageOffset(diopiConstTensorHandle_t pth, int64_t *pOffset) {
+  *pOffset = (reinterpret_cast<const at::Tensor *>(pth))->storage_offset();
   return diopiSuccess;
 }
 
-DIOPI_RT_API diopiError_t diopiGetTensorStorageNbytes(
-    diopiConstTensorHandle_t pth, size_t* pNbytes) {
-  *pNbytes = (reinterpret_cast<const at::Tensor*>(pth))->storage().nbytes();
+DIOPI_RT_API diopiError_t
+diopiGetTensorStorageNbytes(diopiConstTensorHandle_t pth, size_t *pNbytes) {
+  *pNbytes = (reinterpret_cast<const at::Tensor *>(pth))->storage().nbytes();
   return diopiSuccess;
 }
 
 DIOPI_RT_API diopiError_t diopiGetTensorDeviceIndex(
-    diopiConstTensorHandle_t pth, diopiDeviceIndex_t* pDevIndex) {
-  *pDevIndex = (reinterpret_cast<const at::Tensor*>(pth))->device().index();
+    diopiConstTensorHandle_t pth, diopiDeviceIndex_t *pDevIndex) {
+  *pDevIndex = (reinterpret_cast<const at::Tensor *>(pth))->device().index();
   return diopiSuccess;
 }
 


### PR DESCRIPTION
Current version is 12 and cannot use InheritParentConfig, thus clang-format is broken.