### PR TITLE
[DIPU]Wx/check the status of build dipu

### DIFF
--- a/dipu/scripts/ci/ascend/ci_ascend_script.sh
+++ b/dipu/scripts/ci/ascend/ci_ascend_script.sh
@@ -1,5 +1,5 @@
 # !/bin/bash
-set -e
+set -eo pipefail
 echo "pwd: $(pwd)"
 
 function build_diopi_lib() {
@@ -42,7 +42,6 @@ case $1 in
     build_dipu)
         (
             build_all
-            python -c "import torch_dipu; print('build dipu successfully')"
         ) \
         || exit -1;;
     *)

--- a/dipu/scripts/ci/ascend/ci_ascend_script.sh
+++ b/dipu/scripts/ci/ascend/ci_ascend_script.sh
@@ -42,6 +42,7 @@ case $1 in
     build_dipu)
         (
             build_all
+            python -c "import torch_dipu; print('build dipu successfully')"
         ) \
         || exit -1;;
     *)

--- a/dipu/scripts/ci/camb/ci_camb_script.sh
+++ b/dipu/scripts/ci/camb/ci_camb_script.sh
@@ -1,5 +1,5 @@
 # !/bin/bash
-set -e
+set -eo pipefail
 echo "pwd: $(pwd)"
 
 
@@ -45,14 +45,12 @@ case $1 in
     build_dipu)
         (
             build_all
-            python -c "import torch_dipu; print('build dipu successfully')"
         ) || exit -1;;
     build_diopi)
         build_diopi_lib || exit -1;;
     build_dipu_only)
         (
             build_dipu_lib
-            python -c "import torch_dipu; print('build dipu successfully')"
         ) || exit -1;;
     *)
         echo -e "[ERROR] Incorrect option:" $1;

--- a/dipu/scripts/ci/camb/ci_camb_script.sh
+++ b/dipu/scripts/ci/camb/ci_camb_script.sh
@@ -45,12 +45,14 @@ case $1 in
     build_dipu)
         (
             build_all
+            python -c "import torch_dipu; print('build dipu successfully')"
         ) || exit -1;;
     build_diopi)
         build_diopi_lib || exit -1;;
     build_dipu_only)
         (
             build_dipu_lib
+            python -c "import torch_dipu; print('build dipu successfully')"
         ) || exit -1;;
     *)
         echo -e "[ERROR] Incorrect option:" $1;

--- a/dipu/scripts/ci/droplet/ci_droplet_script.sh
+++ b/dipu/scripts/ci/droplet/ci_droplet_script.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -eo pipefail
 DIOPI_IMPL=${3:-droplet}
 DIPU_DEVICE=${2:-droplet}
 

--- a/dipu/scripts/ci/nv/ci_nv_script.sh
+++ b/dipu/scripts/ci/nv/ci_nv_script.sh
@@ -21,9 +21,15 @@ function build() {
 
 case $1 in
     "build_dipu")
-        build ;;
+        (
+            build
+            python -c "import torch_dipu; print('build dipu successfully')"
+        ) || exit -1;;
     "build_dipu_only")
-        build "-DWITH_DIOPI_LIBRARY=DISABLE" ;;
+        (
+            build "-DWITH_DIOPI_LIBRARY=DISABLE"
+            python -c "import torch_dipu; print('build dipu successfully')"
+        ) || exit -1;;
     *)
         echo "[ERROR] Incorrect option: $1" && exit 1 ;;
 esac

--- a/dipu/scripts/ci/nv/ci_nv_script.sh
+++ b/dipu/scripts/ci/nv/ci_nv_script.sh
@@ -1,5 +1,5 @@
 # !/bin/bash
-set -e
+set -eo pipefail
 
 function build() {
     path="build"
@@ -21,15 +21,9 @@ function build() {
 
 case $1 in
     "build_dipu")
-        (
-            build
-            python -c "import torch_dipu; print('build dipu successfully')"
-        ) || exit -1;;
+        build ;;
     "build_dipu_only")
-        (
-            build "-DWITH_DIOPI_LIBRARY=DISABLE"
-            python -c "import torch_dipu; print('build dipu successfully')"
-        ) || exit -1;;
+        build "-DWITH_DIOPI_LIBRARY=DISABLE" ;;
     *)
         echo "[ERROR] Incorrect option: $1" && exit 1 ;;
 esac

--- a/dipu/scripts/ci/topsrider/ci_topsrider_script.sh
+++ b/dipu/scripts/ci/topsrider/ci_topsrider_script.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -eo pipefail
 
 function config_dipu_cmake() {
     mkdir -p build && cd ./build && rm -rf ./*


### PR DESCRIPTION
原先CI在build dipu失败时是成功退出，继续执行下面的job，原因为：默认情况下，管道命令的返回值是最后一个命令的退出状态【原始脚本中在管道后采用了tee命令，触发了bug】。启用`pipefail`选项后，管道命令的返回值将变为其中任何一个命令失败时的返回值（即最左边的非零退出状态），这有助于检测和处理管道中间某个命令的错误。