### PR TITLE
[dipu] Speedup `dumpOnArgLevel()` by using lazy initialization

### DIFF
--- a/dipu/SupportedDiopiFunctions.txt
+++ b/dipu/SupportedDiopiFunctions.txt
@@ -48,6 +48,8 @@ diopiCastDtype
 diopiCat
 diopiCdist
 diopiCdistBackward
+diopiCeil
+diopiCeilInp
 diopiClamp
 diopiClampInp
 diopiClampInpScalar
@@ -135,6 +137,10 @@ diopiLog2
 diopiLog2Inp
 diopiLogicalAnd
 diopiLogicalAndInp
+diopiLogicalNot
+diopiLogicalNotInp
+diopiLogicalOr
+diopiLogicalOrInp
 diopiLogInp
 diopiLogSoftmax
 diopiLogSoftmaxBackward

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -35,8 +35,8 @@ inline void synchronizeIfEnable() {
 }
 
 inline int dumpOpArgLevel() {
-  const char* env_ptr = std::getenv("DIPU_DUMP_OP_ARGS");
-  int level = env_ptr ? std::atoi(env_ptr) : 0;
+  static const char* env_ptr = std::getenv("DIPU_DUMP_OP_ARGS");
+  static int level = env_ptr ? std::atoi(env_ptr) : 0;
   return level;
 }
 


### PR DESCRIPTION
Reduced ~5% training time in torchvision ResNet-18 (batch_size=1).