### PR TITLE
Ywt/optimize op print info log

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -29,8 +29,8 @@ add_custom_command(
   COMMAND
     python "${DIPU_AUTOGEN_DIOPI_WRAPPER_SCRIPT}" --config
     "${DIPU_AUTOGEN_DIOPI_WRAPPER_CONFIG}" --out "${DIPU_AUTOGENED_KERNELS_CPP}"
-    --use_diopi_adapter "False" --autocompare "False" --print_func_call_info "False"
-    --print_op_arg "False" --fun_config_dict
+    --use_diopi_adapter "False" --autocompare "False" --print_func_call_info "True"
+    --print_op_arg "True" --fun_config_dict
     '{\"current_device\": \"${UsedVendor}\"}'
   DEPENDS ${DIPU_AUTOGEN_DIOPI_WRAPPER_SCRIPT}
           ${DIPU_AUTOGEN_DIOPI_WRAPPER_CONFIG}

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -29,8 +29,8 @@ add_custom_command(
   COMMAND
     python "${DIPU_AUTOGEN_DIOPI_WRAPPER_SCRIPT}" --config
     "${DIPU_AUTOGEN_DIOPI_WRAPPER_CONFIG}" --out "${DIPU_AUTOGENED_KERNELS_CPP}"
-    --use_diopi_adapter "False" --autocompare "False" --print_func_call_info "True"
-    --print_op_arg "True" --fun_config_dict
+    --use_diopi_adapter "False" --autocompare "False" --print_func_call_info "False"
+    --print_op_arg "False" --fun_config_dict
     '{\"current_device\": \"${UsedVendor}\"}'
   DEPENDS ${DIPU_AUTOGEN_DIOPI_WRAPPER_SCRIPT}
           ${DIPU_AUTOGEN_DIOPI_WRAPPER_CONFIG}

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -35,8 +35,13 @@ inline void synchronizeIfEnable() {
 }
 
 inline int dumpOpArgLevel() {
-  const char* env_ptr = std::getenv("DIPU_DUMP_OP_ARGS");
-  int level = env_ptr ? std::atoi(env_ptr) : 0;
+  static const int level = []() {
+    const char* env_ptr = std::getenv("DIPU_DUMP_OP_ARGS");
+    auto level = env_ptr ? std::atoi(env_ptr) : 0;
+    DIPU_LOG << "Reading environment variable `DIPU_DUMP_OP_ARGS` "
+             << "and gets level: " << level << std::endl;
+    return level;
+  }();
   return level;
 }
 

--- a/dipu/torch_dipu/csrc_dipu/utils/Log.h
+++ b/dipu/torch_dipu/csrc_dipu/utils/Log.h
@@ -8,13 +8,13 @@
 #define CONCAT(prefix, suffix) CONCAT_(prefix, suffix)
 #define MAKE_UNIQUE_VARIABLE_NAME(prefix) CONCAT(prefix##_, __LINE__)
 
-#define DIPU_LOG std::cout << __FILE__ << ":" << __LINE__ << "DIPU_LOG: "
+#define DIPU_LOG std::cout << __FILE__ << ":" << __LINE__ << " DIPU_LOG: "
 #define DIPU_LOG_ONCE                                                        \
   static auto& __attribute__((unused)) MAKE_UNIQUE_VARIABLE_NAME(__func__) = \
       DIPU_LOG
 
 #define DIPU_LOG_ERROR \
-  std::cerr << __FILE__ << ":" << __LINE__ << "DIPU_ERROR:  "
+  std::cerr << __FILE__ << ":" << __LINE__ << " DIPU_ERROR:  "
 #define DIPU_LOG_ERROR_ONCE                                                  \
   static auto& __attribute__((unused)) MAKE_UNIQUE_VARIABLE_NAME(__func__) = \
       DIPU_LOG_ERROR

--- a/dipu/torch_dipu/csrc_dipu/utils/Log.h
+++ b/dipu/torch_dipu/csrc_dipu/utils/Log.h
@@ -13,7 +13,8 @@
   static auto& __attribute__((unused)) MAKE_UNIQUE_VARIABLE_NAME(__func__) = \
       DIPU_LOG
 
-#define DIPU_LOG_ERROR std::cerr << __FILE__ << ":" << __LINE__ << "DIPU_ERROR:  "
+#define DIPU_LOG_ERROR \
+  std::cerr << __FILE__ << ":" << __LINE__ << "DIPU_ERROR:  "
 #define DIPU_LOG_ERROR_ONCE                                                  \
   static auto& __attribute__((unused)) MAKE_UNIQUE_VARIABLE_NAME(__func__) = \
       DIPU_LOG_ERROR

--- a/dipu/torch_dipu/csrc_dipu/utils/Log.h
+++ b/dipu/torch_dipu/csrc_dipu/utils/Log.h
@@ -8,12 +8,12 @@
 #define CONCAT(prefix, suffix) CONCAT_(prefix, suffix)
 #define MAKE_UNIQUE_VARIABLE_NAME(prefix) CONCAT(prefix##_, __LINE__)
 
-#define DIPU_LOG std::cout << __FILE__ << ":" << __LINE__ << " "
+#define DIPU_LOG std::cout << __FILE__ << ":" << __LINE__ << "DIPU_LOG: "
 #define DIPU_LOG_ONCE                                                        \
   static auto& __attribute__((unused)) MAKE_UNIQUE_VARIABLE_NAME(__func__) = \
       DIPU_LOG
 
-#define DIPU_LOG_ERROR std::cerr << __FILE__ << ":" << __LINE__ << " "
+#define DIPU_LOG_ERROR std::cerr << __FILE__ << ":" << __LINE__ << "DIPU_ERROR:  "
 #define DIPU_LOG_ERROR_ONCE                                                  \
   static auto& __attribute__((unused)) MAKE_UNIQUE_VARIABLE_NAME(__func__) = \
       DIPU_LOG_ERROR


### PR DESCRIPTION
- close print op log info by default
- optimize fetching environment variable
- performance of yolov5: 73.4% -> 74.0%