### PR TITLE
[DIPU] Move static global variables into static functions.

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
@@ -4,6 +4,7 @@
 #include <ATen/ATen.h>
 #include <ATen/MemoryOverlap.h>
 #include <ATen/Tensor.h>
+#include <c10/core/Stream.h>
 
 #include <csrc_dipu/aten/DIPUATenFunctions.h>
 #include <csrc_dipu/aten/ops/OpUtils.hpp>
@@ -46,7 +47,7 @@ inline void tryRecordStream(const at::Tensor& tensor, DIPUStream& curStream,
                             bool is_default_stream) {
   if ((tensor.is_cpu() && tensor.options().pinned_memory()) ||
       !is_default_stream) {
-    tensor.record_stream(curStream);
+    tensor.record_stream(static_cast<c10::Stream>(curStream));
   }
 }
 

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
@@ -47,7 +47,7 @@ inline void tryRecordStream(const at::Tensor& tensor, DIPUStream& curStream,
                             bool is_default_stream) {
   if ((tensor.is_cpu() && tensor.options().pinned_memory()) ||
       !is_default_stream) {
-    tensor.record_stream(static_cast<c10::Stream>(curStream));
+    tensor.record_stream(curStream.unwrap());
   }
 }
 

--- a/dipu/torch_dipu/csrc_dipu/base/basedef.h
+++ b/dipu/torch_dipu/csrc_dipu/base/basedef.h
@@ -6,8 +6,6 @@
 
 #include <csrc_dipu/runtime/device/basedef.h>
 
-auto static constexpr C10_COMPILE_TIME_MAX_DIPUS = 16;
-
 #define DIPU_DEVICE_TYPE_MACRO XPU
 #define DIPU_AUTOGRAD_DEVICE_TYPE_MACRO \
   C10_CONCATENATE(Autograd, DIPU_DEVICE_TYPE_MACRO)

--- a/dipu/torch_dipu/csrc_dipu/profiler/profiler.h
+++ b/dipu/torch_dipu/csrc_dipu/profiler/profiler.h
@@ -170,7 +170,7 @@ class RecordBlockCreator {
         if (!streamId) {
           streamId = dipu_stream.id();
         }
-        stream = static_cast<deviceStream_t>(dipu_stream);
+        stream = dipu_stream.rawstream();
       }
       initialize(string_t(name), std::move(*extraInfo), *stream, *streamId);
     }

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUEvent.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUEvent.h
@@ -81,14 +81,14 @@ class DIPU_API DIPUEvent {
                 device_index_, " does not match recording stream's device ",
                 stream.device_index(), ".");
     DIPUGuard guard(device_index_);
-    devproxy::recordEvent(event_, stream);
+    devproxy::recordEvent(event_, stream.rawstream());
     was_recorded_ = true;
   }
 
   void wait(const DIPUStream& stream) {
     if (isCreated()) {
       DIPUGuard guard(stream.device_index());
-      devproxy::streamWaitEvent(stream, event_);
+      devproxy::streamWaitEvent(stream.rawstream(), event_);
     }
   }
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.cpp
@@ -74,9 +74,8 @@ struct DIPUStreamDevice {
 
   void _doInitPool() {
     DIPUGuard device_guard{devidx_};
-    for (auto i = decltype(kStreamsPerPool){0}; i < kStreamsPerPool; ++i) {
-      auto& raw_device_stream = pool_streams[i];
-      devproxy::createStream(&raw_device_stream);
+    for (auto& stream : pool_streams) {
+      devproxy::createStream(&stream);
     }
   }
 
@@ -212,7 +211,7 @@ void setCurrentDIPUStream(DIPUStream stream) {
   auto device_index = stream.device_index();
   // TODO(assert): assert(setupDevice(device_index) == device_index)
   setupDevice(device_index);
-  LocalStreams()[device_index] = static_cast<c10::Stream>(stream).id();
+  LocalStreams()[device_index] = stream.unwrap().id();
 }
 
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.cpp
@@ -154,7 +154,12 @@ auto LocalStreams() -> std::vector<c10::StreamId>& {
   return streams;
 }
 
-auto const& trigger = std::make_tuple(LocalStreams());
+// TODO(lifetime): remove it someday.
+//
+// This static variable is used to initialize StreamDevice and StreamIds. As
+// BFCachingAllocator depends on them via getDefaultDIPUStream. We need to make
+// sure its lifetime longer than static BFCachingAllocator.
+auto const& force_to_initialize_streams = LocalStreams();
 
 c10::DeviceIndex setupDevice(c10::DeviceIndex device_index) {
   if (device_index == -1) {

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.cpp
@@ -154,6 +154,8 @@ auto LocalStreams() -> std::vector<c10::StreamId>& {
   return streams;
 }
 
+auto const& trigger = std::make_tuple(LocalStreams());
+
 c10::DeviceIndex setupDevice(c10::DeviceIndex device_index) {
   if (device_index == -1) {
     device_index = devproxy::current_device();
@@ -165,7 +167,6 @@ c10::DeviceIndex setupDevice(c10::DeviceIndex device_index) {
   // help message. We need our version.
   AT_ASSERT(0 <= device_index && device_index < number_of_device);
   device_list[device_index]->initDevice();
-
   return device_index;
 }
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.h
@@ -29,15 +29,12 @@ class DIPU_API DIPUStream {
                                stream_id)) {}
 
   bool operator==(const DIPUStream& other) const noexcept {
-    return static_cast<c10::Stream>(*this) == static_cast<c10::Stream>(other);
+    return unwrap() == other.unwrap();
   }
 
   bool operator!=(const DIPUStream& other) const noexcept {
     return not operator==(other);
   }
-
-  explicit operator c10::Stream() const { return stream_; }
-  operator deviceStream_t() const { return rawstream(); }
 
   /// Get the device index that this stream is associated with.
   c10::DeviceIndex device_index() const { return stream_.device_index(); }
@@ -60,7 +57,8 @@ class DIPU_API DIPUStream {
     return devproxy::isStreamEmpty(rawstream());
   }
 
-  /// Explicit conversion to rtStream_t.
+  c10::Stream unwrap() const { return stream_; }
+
   deviceStream_t rawstream() const;
 };
 
@@ -77,13 +75,13 @@ DIPU_API DIPUStream getStreamFromExternal(deviceStream_t ext_stream,
 
 template <typename O>
 inline O& operator<<(O& oss, const dipu::DIPUStream& stream) {
-  oss << static_cast<c10::Stream>(stream);
+  oss << stream.unwrap();
 }
 }  // namespace dipu
 
 template <>
 struct std::hash<dipu::DIPUStream> {
   std::size_t operator()(dipu::DIPUStream const& s) const noexcept {
-    return std::hash<c10::Stream>{}(static_cast<c10::Stream>(s));
+    return std::hash<c10::Stream>{}(s.unwrap());
   }
 };

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.h
@@ -1,15 +1,10 @@
 // Copyright (c) 2023, DeepLink.
 #pragma once
 
-#include <cstdint>
-#include <functional>
-#include <mutex>
-
 #include <c10/core/Device.h>
 #include <c10/core/DeviceGuard.h>
 #include <c10/core/Stream.h>
 #include <c10/util/Exception.h>
-#include <c10/util/SmallVector.h>
 
 #include <csrc_dipu/base/basedef.h>
 #include <csrc_dipu/runtime/devproxy/deviceproxy.h>
@@ -17,31 +12,31 @@
 namespace dipu {
 
 class DIPU_API DIPUStream {
+ private:
+  c10::Stream stream_;
+
  public:
+  // Need more discussion to handle empty DIPUStream.
+  explicit DIPUStream() : DIPUStream(-1, 0) {}
+
   explicit DIPUStream(c10::Stream stream) : stream_(stream) {
     TORCH_CHECK(stream_.device_type() == dipu::DIPU_DEVICE_TYPE);
   }
 
-  explicit DIPUStream(devapis::deviceId_t devidx, c10::StreamId stream_id)
+  explicit DIPUStream(devapis::deviceId_t device_id, c10::StreamId stream_id)
       : DIPUStream(c10::Stream(c10::Stream::UNSAFE,
-                               c10::Device(dipu::DIPU_DEVICE_TYPE, devidx),
+                               c10::Device(dipu::DIPU_DEVICE_TYPE, device_id),
                                stream_id)) {}
 
-  // Need more discussion to handle empty DIPUStream.
-  explicit DIPUStream() : DIPUStream(-1, 0) {}
-
-  ~DIPUStream() = default;
-
   bool operator==(const DIPUStream& other) const noexcept {
-    return unwrap() == other.unwrap();
+    return static_cast<c10::Stream>(*this) == static_cast<c10::Stream>(other);
   }
 
   bool operator!=(const DIPUStream& other) const noexcept {
-    return unwrap() != other.unwrap();
+    return not operator==(other);
   }
 
-  // FIXME: add explicit later as it is used by many other files.
-  operator c10::Stream() const { return unwrap(); }
+  explicit operator c10::Stream() const { return stream_; }
   operator deviceStream_t() const { return rawstream(); }
 
   /// Get the device index that this stream is associated with.
@@ -67,21 +62,6 @@ class DIPU_API DIPUStream {
 
   /// Explicit conversion to rtStream_t.
   deviceStream_t rawstream() const;
-
-  /// Explicit conversion to Stream.
-  c10::Stream unwrap() const { return stream_; }
-
-  c10::StreamData3 pack3() const noexcept { return stream_.pack3(); }
-
-  static DIPUStream unpack3(c10::StreamId stream_id,
-                            c10::DeviceIndex device_index,
-                            c10::DeviceType device_type) {
-    TORCH_CHECK(device_type == dipu::DIPU_DEVICE_TYPE);
-    return DIPUStream(device_index, stream_id);
-  }
-
- private:
-  c10::Stream stream_;
 };
 
 DIPU_API DIPUStream getDIPUStreamFromPool(c10::DeviceIndex device_index = -1);
@@ -95,12 +75,15 @@ DIPU_API void setCurrentDIPUStream(DIPUStream stream);
 DIPU_API DIPUStream getStreamFromExternal(deviceStream_t ext_stream,
                                           c10::DeviceIndex device_index);
 
-std::ostream& operator<<(std::ostream& stream, const DIPUStream& s);
+template <typename O>
+inline O& operator<<(O& oss, const dipu::DIPUStream& stream) {
+  oss << static_cast<c10::Stream>(stream);
+}
 }  // namespace dipu
 
 template <>
 struct std::hash<dipu::DIPUStream> {
   std::size_t operator()(dipu::DIPUStream const& s) const noexcept {
-    return std::hash<c10::Stream>{}(s.unwrap());
+    return std::hash<c10::Stream>{}(static_cast<c10::Stream>(s));
   }
 };

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUStream.h
@@ -74,7 +74,7 @@ DIPU_API DIPUStream getStreamFromExternal(deviceStream_t ext_stream,
                                           c10::DeviceIndex device_index);
 
 template <typename O>
-inline O& operator<<(O& oss, const dipu::DIPUStream& stream) {
+O& operator<<(O& oss, const dipu::DIPUStream& stream) {
   oss << stream.unwrap();
 }
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBFCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBFCachingAllocator.cpp
@@ -470,11 +470,11 @@ class BFCachingAllocator : public CacheAllocator {
       if (allocator_->impl) {
         if (ptr()) {
           std::deque<DIPUEvent> events;
-          for (auto iter = streams().begin(); iter != streams().end(); iter++) {
+          for (auto const& stream : streams()) {
             events.emplace_back();
             DIPU_DEBUG_ALLOCATOR(8, "BFCachingAllocator: record to stream:"
-                                        << iter->rawstream());
-            events.back().record(*iter);
+                                        << stream.rawstream());
+            events.back().record(stream);
           }
           allocator_->async_mem_pool()->add(std::make_tuple(ptr(), id_),
                                             events);

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.cpp
@@ -201,13 +201,9 @@ size_t maxMemoryAllocated(const c10::Device& device) {
 }
 
 void recordStream(const c10::DataPtr& ptr, const DIPUStream& stream) {
-  void* ctx = ptr.get_context();
-  if (ctx == nullptr) {
-    return;
-  }
-  auto base_cxt = static_cast<CacheAllocator::DataPtrContextBase*>(ctx);
-  if (base_cxt) {
-    base_cxt->streams().insert(stream);
+  using pointer = CacheAllocator::DataPtrContextBase*;
+  if (auto ctx = static_cast<pointer>(ptr.get_context())) {
+    ctx->streams().insert(stream);
   }
 }
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
@@ -1,10 +1,9 @@
 // Copyright (c) 2023, DeepLink.
 #pragma once
 
-#include <unordered_set>
-
 #include <c10/core/Allocator.h>
 #include <c10/core/Device.h>
+#include <c10/util/flat_hash_map.h>
 
 #include "DIPUAsyncResourcePool.h"
 #include "DIPURawAllocator.h"
@@ -93,7 +92,7 @@ class DIPU_API CacheAllocator : public c10::Allocator, public MemStats {
   c10::Device& device() const { return device_; }
 
   class DataPtrContextBase {
-    std::unordered_set<DIPUStream> streams_;
+    ska::flat_hash_set<DIPUStream> streams_;
     mutable const CacheAllocator* allocator_ = nullptr;
     void* ptr_ = nullptr;
     size_t size_ = 0;
@@ -115,7 +114,7 @@ class DIPU_API CacheAllocator : public c10::Allocator, public MemStats {
 
     ~DataPtrContextBase() { MemChecker::instance().erase(ptr_); }
 
-    std::unordered_set<DIPUStream>& streams() { return streams_; }
+    ska::flat_hash_set<DIPUStream>& streams() { return streams_; }
 
     const CacheAllocator* allocator() { return allocator_; }
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
@@ -1,9 +1,7 @@
 // Copyright (c) 2023, DeepLink.
 #pragma once
 
-#include <list>
-#include <map>
-#include <set>
+#include <unordered_set>
 
 #include <c10/core/Allocator.h>
 #include <c10/core/Device.h>
@@ -98,8 +96,7 @@ class DIPU_API CacheAllocator : public c10::Allocator, public MemStats {
   c10::Device& device() const { return device_; }
 
   class DataPtrContextBase {
-   private:
-    std::set<DIPUStream> streams_;
+    std::unordered_set<DIPUStream> streams_;
     mutable const CacheAllocator* allocator_ = nullptr;
     void* ptr_ = nullptr;
     size_t size_ = 0;
@@ -121,7 +118,7 @@ class DIPU_API CacheAllocator : public c10::Allocator, public MemStats {
 
     ~DataPtrContextBase() { MemChecker::instance().erase(ptr_); }
 
-    std::set<DIPUStream>& streams() { return streams_; }
+    std::unordered_set<DIPUStream>& streams() { return streams_; }
 
     const CacheAllocator* allocator() { return allocator_; }
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/guardimpl/DIPUGuardImpl.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/guardimpl/DIPUGuardImpl.h
@@ -4,6 +4,7 @@
 
 #include <limits>
 
+#include <c10/core/Stream.h>
 #include <c10/core/impl/DeviceGuardImplInterface.h>
 #include <c10/macros/Macros.h>
 
@@ -49,7 +50,7 @@ struct DIPUGuardImpl : public c10::impl::DeviceGuardImplInterface {
   }
 
   c10::Stream getStream(c10::Device device) const noexcept override {
-    return getCurrentDIPUStream(device.index()).unwrap();
+    return static_cast<c10::Stream>(getCurrentDIPUStream(device.index()));
   }
 
   c10::Stream exchangeStream(c10::Stream s) const noexcept override {
@@ -66,11 +67,11 @@ struct DIPUGuardImpl : public c10::impl::DeviceGuardImplInterface {
 
   c10::Stream getStreamFromGlobalPool(c10::Device d,
                                       bool isHighPriority) const override {
-    return getDIPUStreamFromPool(d.index());
+    return static_cast<c10::Stream>(getDIPUStreamFromPool(d.index()));
   }
 
   c10::Stream getDefaultStream(c10::Device device) const override {
-    return getDefaultDIPUStream(device.index());
+    return static_cast<c10::Stream>(getDefaultDIPUStream(device.index()));
   }
 
   void record(void** event, const c10::Stream& s,

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/guardimpl/DIPUGuardImpl.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/guardimpl/DIPUGuardImpl.h
@@ -50,7 +50,7 @@ struct DIPUGuardImpl : public c10::impl::DeviceGuardImplInterface {
   }
 
   c10::Stream getStream(c10::Device device) const noexcept override {
-    return static_cast<c10::Stream>(getCurrentDIPUStream(device.index()));
+    return getCurrentDIPUStream(device.index()).unwrap();
   }
 
   c10::Stream exchangeStream(c10::Stream s) const noexcept override {
@@ -67,11 +67,11 @@ struct DIPUGuardImpl : public c10::impl::DeviceGuardImplInterface {
 
   c10::Stream getStreamFromGlobalPool(c10::Device d,
                                       bool isHighPriority) const override {
-    return static_cast<c10::Stream>(getDIPUStreamFromPool(d.index()));
+    return getDIPUStreamFromPool(d.index()).unwrap();
   }
 
   c10::Stream getDefaultStream(c10::Device device) const override {
-    return static_cast<c10::Stream>(getDefaultDIPUStream(device.index()));
+    return getDefaultDIPUStream(device.index()).unwrap();
   }
 
   void record(void** event, const c10::Stream& s,
@@ -84,7 +84,6 @@ struct DIPUGuardImpl : public c10::impl::DeviceGuardImplInterface {
 
     auto dipu_event = static_cast<deviceEvent_t>(*event);
     auto stream = DIPUStream(s);
-    auto raw_stream = stream.rawstream();
 
     // Moves to queue's device to record
     const c10::Device orig_device = this->getDevice();
@@ -94,7 +93,7 @@ struct DIPUGuardImpl : public c10::impl::DeviceGuardImplInterface {
     if (!dipu_event) {
       devproxy::createEvent(&dipu_event);
     }
-    devproxy::recordEvent(dipu_event, raw_stream);
+    devproxy::recordEvent(dipu_event, stream.rawstream());
     *event = dipu_event;
 
     // Resets device

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/DICLUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/DICLUtils.hpp
@@ -5,6 +5,8 @@
 
 #include <c10/core/Device.h>
 
+#include <csrc_dipu/runtime/core/DIPUEvent.h>
+#include <csrc_dipu/runtime/core/DIPUStream.h>
 #include <csrc_dipu/runtime/devproxy/deviceproxy.h>
 #include <csrc_dipu/runtime/devproxy/diclproxy.h>
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -307,7 +307,7 @@ static inline void copyInCommStream(std::shared_ptr<DICLComm>& diclComm,
                                     const Dest& dest, const Src& src,
                                     int nums) {
   auto diclStream = diclComm->diclStream_;
-  DIPUStreamGuard guard(diclStream.unwrap());
+  DIPUStreamGuard guard(static_cast<c10::Stream>(diclStream));
   for (size_t j = 0; j < nums; ++j) {
     dest[j].copy_(src[j], true);
     if (RecordDest) {
@@ -411,7 +411,7 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::doComm(
   // todo:: dipu need support multistream guard & remove
   // work->workEvents_(future already has events ).
   {
-    DIPUStreamGuard streamGuard(diclComms[0]->diclStream_);
+    DIPUStreamGuard guard(static_cast<c10::Stream>(diclComms[0]->diclStream_));
 
     work->future_ = c10::make_intrusive<at::ivalue::Future>(
         c10::ListType::create(c10::TensorType::get()), devices);

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -307,7 +307,7 @@ static inline void copyInCommStream(std::shared_ptr<DICLComm>& diclComm,
                                     const Dest& dest, const Src& src,
                                     int nums) {
   auto diclStream = diclComm->diclStream_;
-  DIPUStreamGuard guard(static_cast<c10::Stream>(diclStream));
+  DIPUStreamGuard guard(diclStream.unwrap());
   for (size_t j = 0; j < nums; ++j) {
     dest[j].copy_(src[j], true);
     if (RecordDest) {
@@ -411,7 +411,7 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::doComm(
   // todo:: dipu need support multistream guard & remove
   // work->workEvents_(future already has events ).
   {
-    DIPUStreamGuard guard(static_cast<c10::Stream>(diclComms[0]->diclStream_));
+    DIPUStreamGuard guard(diclComms[0]->diclStream_.unwrap());
 
     work->future_ = c10::make_intrusive<at::ivalue::Future>(
         c10::ListType::create(c10::TensorType::get()), devices);


### PR DESCRIPTION
本次 PR 涉及到两个修改：

1. 删除 `DIPUStream` 的无用接口，对部分接口新增 explicit 限制
2. 将 `DIPUStream.cpp` 中的部分全局变量重构为 static 函数内的 static 变量