### PR TITLE
[dipu] Optimize `getAllocator` by adopting lookup table

### DIFF
--- a/dipu/.clang-tidy
+++ b/dipu/.clang-tidy
@@ -3,6 +3,7 @@ Checks: '
   bugprone-*,
   -bugprone-easily-swappable-parameters,
   -bugprone-reserved-identifier,
+  -bugprone-signed-char-misuse,
   clang-analyzer-*,
   clang-diagnostic-*,
   cppcoreguidelines-*,
@@ -39,8 +40,6 @@ AnalyzeTemporaryDtors: false
 FormatStyle: file
 HeaderFilterRegex: '.*'
 CheckOptions:
-  - key:   bugprone-signed-char-misuse.CharTypdefsToIgnore
-    value: 'int8_t;c10::DeviceIndex'
   - key:   cppcoreguidelines-avoid-do-while.IgnoreMacros
     value: true
   - key:   cppcoreguidelines-narrowing-conversions.IgnoreConversionFromTypes

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.cpp
@@ -10,6 +10,8 @@
 #include <c10/core/Device.h>
 #include <c10/core/DeviceType.h>
 
+#include "csrc_dipu/base/basedef.h"
+
 namespace dipu {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
@@ -76,6 +78,16 @@ void setAllocator(const std::string& name, c10::DeviceType device_type,
 
 namespace {
 
+int getDeviceIndex(const c10::Device& device) {
+  if (device.is_cpu()) {
+    return 0;
+  }
+  if (device.has_index()) {
+    return device.index();
+  }
+  return devproxy::current_device();
+}
+
 c10::Allocator* createAllocator(const c10::Device& device) {
   c10::DeviceType device_type = device.type();
   c10::Allocator* result = nullptr;
@@ -86,11 +98,7 @@ c10::Allocator* createAllocator(const c10::Device& device) {
   if (gDIPURegisteredAllocator[device_type].count(algorithm) > 0) {
     auto allocator_geter =
         std::get<0>(gDIPURegisteredAllocator[device_type][algorithm]);
-    int device_index = 0;
-    if (device_type == dipu::DIPU_DEVICE_TYPE) {
-      device_index =
-          device.has_index() ? device.index() : devproxy::current_device();
-    }
+    int device_index = getDeviceIndex(device);
 
     auto allocator = allocator_geter(device_index);
     if (device_type == dipu::DIPU_DEVICE_TYPE) {
@@ -108,15 +116,12 @@ c10::Allocator* createAllocator(const c10::Device& device) {
 
 c10::Allocator* getAllocator(const c10::Device& device) {
   // allocator_lookup_table[device_type][device_index]
-  static std::array<
-      std::array<c10::Allocator*, allocator_details::kMaxDeviceNumber>,
-      static_cast<std::size_t>(c10::DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES)>
+  static std::array<std::array<c10::Allocator*, C10_COMPILE_TIME_MAX_DIPUS>,
+                    static_cast<std::size_t>(
+                        c10::DeviceType::COMPILE_TIME_MAX_DEVICE_TYPES)>
       allocator_lookup_table{};
   auto device_type = static_cast<int>(device.type());
-  int device_index =
-      device.type() == dipu::DIPU_DEVICE_TYPE
-          ? device.has_index() ? device.index() : devproxy::current_device()
-          : 0;
+  int device_index = getDeviceIndex(device);
   auto& allocator = allocator_lookup_table[device_type][device_index];
   if (allocator == nullptr) {
     allocator = createAllocator(device);

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
@@ -176,6 +176,8 @@ c10::Allocator* get_allocator_impl(c10::Allocator* raw_allocator) {
   return &cache_allocator;
 }
 
+constexpr int kMaxDeviceNumber = 16;
+
 template <class AllocatorImpl, class AsyncMemPoolImpl>
 c10::Allocator* get_allocator(int device_id, c10::Allocator* raw_allocator) {
 #define DIPU_ALLOCATOR_DISPATCH_DEVICE_ID(id)                       \

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
@@ -1,17 +1,12 @@
 // Copyright (c) 2023, DeepLink.
 #pragma once
 
-#include <list>
-#include <map>
 #include <set>
 
 #include <c10/core/Allocator.h>
 #include <c10/core/Device.h>
 
-#include "csrc_dipu/runtime/core/DIPUEvent.h"
-
 #include "DIPUAsyncResourcePool.h"
-#include "DIPUCachingAllocatorUtils.h"
 #include "DIPURawAllocator.h"
 
 namespace dipu {

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
@@ -171,8 +171,6 @@ c10::Allocator* get_allocator_impl(c10::Allocator* raw_allocator) {
   return &cache_allocator;
 }
 
-constexpr int kMaxDeviceNumber = 16;
-
 template <class AllocatorImpl, class AsyncMemPoolImpl>
 c10::Allocator* get_allocator(int device_id, c10::Allocator* raw_allocator) {
 #define DIPU_ALLOCATOR_DISPATCH_DEVICE_ID(id)                       \

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/deviceproxy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/deviceproxy.cpp
@@ -41,7 +41,10 @@ void syncDevice() { return devapis::syncDevice(); }
 // check last launch succ or not, throw if fail
 void checkLastError() { return devapis::checkLastError(); }
 
-int getDeviceCount() { return devapis::getDeviceCount(); }
+int getDeviceCount() {
+  static int device_count = devapis::getDeviceCount();
+  return device_count;
+}
 
 void getDriverVersion(int* version) {
   return devapis::getDriverVersion(version);

--- a/dipu/torch_dipu/csrc_dipu/vendor/cuda/deviceimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/cuda/deviceimpl.cpp
@@ -62,7 +62,7 @@ void checkLastError() { DIPU_CALLCUDA(::cudaGetLastError()) }
 
 int getDeviceCount() {
   int num = -1;
-  DIPU_CALLCUDA(::cudaGetDeviceCount(reinterpret_cast<int*>(&num)))
+  DIPU_CALLCUDA(::cudaGetDeviceCount(&num))
   return num;
 }
 


### PR DESCRIPTION
Slight improvement on ops like `empty`.
ResNet-18 (batch_size=1, iter=1000) 19.7s->19.6s