### PR TITLE
[dipu] fix: `torch.prod` int type promotion

### DIFF
--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -1,10 +1,10 @@
 - schema: "exampleop.overloadname(Tensor self, Scalar other, Scalar alpha=1, *, Tensor(a!) out) -> Tensor(a!)"
   autocompare: disable
-  register_op: False # Whether generate registe code for this op, default value is True
+  register_op: False # Whether generate register code for this op, default value is True
   print_func_call_info: False # whether generate code that prints function call information
   print_op_args: True # whether generate code that prints op args
-  dummy_call_diopi: False # Does not generate code that actually calls the diopi function, defalut value is False
-  custom_code_at_the_beginning: "/* Here can be a piece of c++ code at the begining*/"
+  dummy_call_diopi: False # Does not generate code that actually calls the diopi function, default value is False
+  custom_code_at_the_beginning: "/* Here can be a piece of c++ code at the beginning*/"
   custom_code_before_call_diopi: |
     std::cout << "self:" << self << std::endl;
     std::cout << "other:" << other << std::endl;
@@ -1084,7 +1084,8 @@
 
 - schema: prod(Tensor self, *, ScalarType? dtype=None) -> Tensor
   custom_code_at_the_beginning: |
-    const auto self_dtype = at::native::to(self, dtype);
+    auto promoted_dtype = at::native::get_dtype_from_self(self, dtype, /*promote_integers=*/true);
+    const auto self_dtype = at::native::to(self, promoted_dtype);
     auto out = at::empty({}, self_dtype.options());
     ::diopiConstTensorHandle_t self_dtype_diopi = dipu::diopi_helper::toDiopiTensorHandle(self_dtype);
   interface: diopiProd(ctx, out, self_dtype_diopi, nullptr)
@@ -2417,7 +2418,7 @@
     return out;
   interface: diopiNorm(ctx, out, self, p, dimDiopiSize);
 
-# wrap_diopi_cast_dtype has no corresponding aten op and not registed, it's just a diopi func wrapper.
+# wrap_diopi_cast_dtype has no corresponding aten op and not registered, it's just a diopi func wrapper.
 # use this tricky method to support call multiple diopi-op in one aten-op
 - schema: "wrap_diopi_cast_dtype(Tensor(a) self, ScalarType dtype) -> Tensor(a)"
   register_op: False

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
@@ -1,38 +1,39 @@
 # Copyright (c) 2023, DeepLink.
 diopi_wrapper_file_template_content = \
-"""
-// autogened file
-#include <ATen/Tensor.h>
+"""// autogened file
+#include <vector>
+
 #include <ATen/ATen.h>
 #include <ATen/Functions.h>
-#include <type_traits>
-
+#include <ATen/Tensor.h>
+#include <ATen/native/ReduceOpsUtils.h>
 #include <torch/csrc/autograd/custom_function.h>
 #include <torch/types.h>
-#include "csrc_dipu/aten/DIPUATenFunctions.h"
+
 #include "csrc_dipu/aten/RegisterDIPU.hpp"
+#include "csrc_dipu/aten/ops/DIPUCopy.hpp"
 #include "csrc_dipu/diopirt/diopirt_impl.h"
 #include "csrc_dipu/profiler/profiler.h"
-#include <csrc_dipu/utils/Log.h>
+
 #include "CustomFallbackFunctions.hpp"
-#include "csrc_dipu/aten/ops/DIPUCopy.hpp"
-#include <vector>
 
 $header_include_code
 
-// NOTE: some kernels (e.g. _foreach_add_.List) have custom codes at the beginning ending with early return.
-// This is a workaround indended to skip some of the autogened codes (e.g. type cast, calling DIOPI, etc.).
+// NOTE: Some kernels (e.g. _foreach_add_.List) have custom codes at the
+// beginning ending with early return. This is a workaround intended to skip
+// some of the autogened codes (e.g. type cast, calling DIOPI, etc.).
+//
 // NOLINTBEGIN(readability-redundant-control-flow)
 
 namespace dipu {
 
 namespace native {
-    
+
 using dipu::diopi_helper::toDiopiGeneratorHandle;
 using dipu::diopi_helper::toDiopiSize;
 using dipu::diopi_helper::toDiopiRoundMode;
 
-$functions_code    
+$functions_code
 
 }  // namespace native
 }  // namespace dipu

--- a/dipu/tests/python/unittests/test_prod.py
+++ b/dipu/tests/python/unittests/test_prod.py
@@ -25,12 +25,12 @@ class TestProd(TestCase):
         input_arrays = [[True, True], [True, False], [False, False]]
         for input_array in input_arrays:
             input_tensor = torch.tensor(input_array)
-            out = torch.prod(input_tensor).item()
-            out_cuda = torch.prod(input_tensor.cuda()).item()
-            self.assertEqual(out, out_cuda)
+            out = torch.prod(input_tensor)
+            out_cuda = torch.prod(input_tensor.cuda())
+            self.assertEqual(out, out_cuda, exact_dtype=True)
 
     def test_prod_dtype(self):
-        test_dtypes = [torch.float16, torch.float32]
+        test_dtypes = [torch.float16, torch.float32, torch.int16, torch.int32, torch.int64]
         for input_dtype in test_dtypes:
             input_tensor = torch.tensor(
                 [[1, 2, 3], [4, 5, 6]], dtype=input_dtype, device="dipu"
@@ -45,6 +45,20 @@ class TestProd(TestCase):
                 )
                 out = torch.prod(input_tensor, 1, dtype=output_dtype)
                 self.assertEqual(out, expected_output, exact_dtype=True)
+
+    def test_prod_integer_promotion(self):
+        test_dtypes = [torch.int8, torch.int16, torch.int32]
+        for input_dtype in test_dtypes:
+            input_tensor = torch.tensor(
+                [[1, 2, 3], [4, 5, 6]], dtype=input_dtype, device="dipu"
+            )
+            expected_output = torch.tensor(720, dtype=torch.int64, device="dipu")
+            out = torch.prod(input_tensor)
+            self.assertEqual(out, expected_output, exact_dtype=True)
+
+            expected_output = torch.tensor([6, 120], dtype=torch.int64, device="dipu")
+            out = torch.prod(input_tensor, 1)
+            self.assertEqual(out, expected_output, exact_dtype=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`prod` (and other reduction ops) should promote int type (including `bool`) to `int64` when `dtype` is not explicitly provided.

Only `prod` (without `dim`) should be taken care of in DIPU, because the other cases are already correctly handled in PyTorch.