### PR TITLE
[DIPU]support using torch profiler on nv

### DIFF
--- a/dipu/tests/python/individual_scripts/test_profiler_communication.py
+++ b/dipu/tests/python/individual_scripts/test_profiler_communication.py
@@ -1,5 +1,8 @@
 import os
+os.environ["FORCE_USE_DIPU_PROFILER"] = "True"
+
 import random
+import tempfile
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -56,7 +59,8 @@ def demo_basic_ddp(rank, world_size, port):
     )
     assert("c10d::allreduce_" in profile_output)
     assert("LaunchKernel_DiclAllreduce" in profile_output)
-    prof.export_chrome_trace(f"./dipu_resnet18_profiler_{rank}.json")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        prof.export_chrome_trace(f"{tmpdir}/dipu_resnet18_profiler_{rank}.json")
     cleanup()
 
 def test_profiler_communication():

--- a/dipu/tests/python/unittests/test_profiler.py
+++ b/dipu/tests/python/unittests/test_profiler.py
@@ -1,14 +1,7 @@
 # Copyright (c) 2023, DeepLink.
-import os
-
-os.environ["FORCE_USE_DIPU_PROFILER"] = "True"
-
 import torch
 import torch_dipu
-import torchvision.models as models
-from torch.profiler import profile, ProfilerActivity
 from torch_dipu.testing._internal.common_utils import TestCase, run_tests, onlyOn
-from torch_dipu.testing._internal.local_eviron import local_eviron
 import torch._dynamo as dynamo
 import subprocess
 
@@ -21,50 +14,7 @@ def check_string_in_directory(directory, search_string):
         return False
 
 
-
 class TestProfiler(TestCase):
-    def test_profiler(self):
-        model = models.resnet18().cuda()
-        inputs = torch.randn(5, 3, 224, 224).cuda()
-
-        with local_eviron({"KINETO_LOG_LEVEL": "999"}):  # suppress profiler logs
-            with profile(
-                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
-                profile_memory=True,
-                record_shapes=True,
-                with_modules=True,
-                with_stack=True,
-                experimental_config=torch._C._profiler._ExperimentalConfig(verbose=True)
-            ) as prof:
-                output = model(inputs)
-                output.sum().backward()
-
-        profile_output = prof.key_averages(group_by_input_shape=True).table(
-            sort_by="self_cuda_time_total", row_limit=1000
-        )
-        self.assertIn("diopiConvolution2dBackward", profile_output)
-        self.assertIn("dipu_convolution_", profile_output)
-        self.assertIn("LaunchKernel_dipu", profile_output)
-        self.assertIn("LaunchKernel_diopi", profile_output)
-        self.assertIn("Self CPU time total", profile_output)
-        self.assertIn("Self CUDA time total", profile_output)
-        self.assertIn("5, 3, 224, 224", profile_output)
-
-        profile_stack_output = prof.key_averages(group_by_stack_n=15).table(
-            sort_by="cuda_time_total", row_limit=1000)
-        self.assertIn("Source Location", profile_stack_output)
-        self.assertIn("resnet.py", profile_stack_output)
-        self.assertIn("test_profiler.py", profile_stack_output)
-
-        profile_memory_output = prof.key_averages().table(
-            sort_by="self_cuda_memory_usage", row_limit=1000)
-        self.assertIn("Self CPU Mem", profile_memory_output)
-        self.assertIn("Self CUDA Mem", profile_memory_output)
-        self.assertIn("Mb", profile_memory_output)
-        self.assertIn("Kb", profile_memory_output)
-
-        prof.export_chrome_trace("./dipu_resnet18_profiler.json")
-
     @onlyOn("NPU")
     def test_aot_profiler(self):
         x = torch.randn(3, 4).cuda()

--- a/dipu/tests/python/unittests/test_profiler.py
+++ b/dipu/tests/python/unittests/test_profiler.py
@@ -1,4 +1,8 @@
 # Copyright (c) 2023, DeepLink.
+import os
+
+os.environ["FORCE_USE_DIPU_PROFILER"] = "True"
+
 import torch
 import torch_dipu
 import torchvision.models as models

--- a/dipu/tests/python/unittests/test_profiler_cuda.py
+++ b/dipu/tests/python/unittests/test_profiler_cuda.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2023, DeepLink.
+import torch
+import torch_dipu
+import torchvision.models as models
+from torch.profiler import profile, ProfilerActivity
+from torch_dipu.testing._internal.common_utils import TestCase, run_tests, onlyOn
+from torch_dipu.testing._internal.local_eviron import local_eviron
+
+
+class TestProfiler(TestCase):
+    @onlyOn("CUDA")
+    def test_profiler(self):
+        model = models.resnet18().cuda()
+        inputs = torch.randn(5, 3, 224, 224).cuda()
+
+        with local_eviron({"KINETO_LOG_LEVEL": "999"}):  # suppress profiler logs
+            with profile(
+                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                profile_memory=True,
+                record_shapes=True,
+                with_modules=True,
+                with_stack=True,
+                experimental_config=torch._C._profiler._ExperimentalConfig(verbose=True)
+            ) as prof:
+                output = model(inputs)
+                output.sum().backward()
+
+        profile_output = prof.key_averages(group_by_input_shape=True).table(
+            sort_by="self_cuda_time_total", row_limit=1000
+        )
+        self.assertNotIn("diopiConvolution2dBackward", profile_output)
+        self.assertNotIn("dipu_convolution_", profile_output)
+        self.assertNotIn("LaunchKernel_dipu", profile_output)
+        self.assertNotIn("LaunchKernel_diopi", profile_output)
+        self.assertIn("aten::cudnn_convolution", profile_output)
+        self.assertIn("aten::add", profile_output)
+        self.assertIn("vectorized_elementwise_kernel", profile_output)
+        self.assertIn("Self CPU time total", profile_output)
+        self.assertIn("Self CUDA time total", profile_output)
+        self.assertIn("5, 3, 224, 224", profile_output)
+
+        profile_stack_output = prof.key_averages(group_by_stack_n=15).table(
+            sort_by="cuda_time_total", row_limit=1000)
+        self.assertIn("Source Location", profile_stack_output)
+        self.assertIn("resnet.py", profile_stack_output)
+
+        profile_memory_output = prof.key_averages().table(
+            sort_by="self_cuda_memory_usage", row_limit=1000)
+        self.assertIn("Self CPU Mem", profile_memory_output)
+        self.assertIn("Self CUDA Mem", profile_memory_output)
+        self.assertIn("Mb", profile_memory_output)
+        self.assertIn("Kb", profile_memory_output)
+
+        prof.export_chrome_trace("./resnet18_profiler.json")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/dipu/torch_dipu/profiler/profiler.py
+++ b/dipu/torch_dipu/profiler/profiler.py
@@ -412,6 +412,12 @@ def dipu_build_table(
 
 
 def apply_profiler_patch():
+    # The data collected by dipu profiler differs significantly from pytorch profiler,
+    # making it difficult to align during performance analysis.
+    # Reuse pytorch profiler logic on NV, while providing environment variables to switch to dipu profiler.
+    if _C.dipu_vendor == 'CUDA' and os.environ.get("FORCE_USE_DIPU_PROFILER", 'False').lower() == 'false' :
+        return
+
     setattr(torch.profiler.profiler, 'kineto_available', dipu_kineto_available)
     setattr(torch.autograd.profiler, 'kineto_available', dipu_kineto_available)
     setattr(torch.autograd.profiler, '_prepare_profiler', _C._prepare_profiler)


### PR DESCRIPTION
### 背景
1. 采集到的数据跟原生差异大，性能分析的时候不容易对齐
2. profiler开销较大，每次kernel调用前后插入两个event的方式

### 解决方案
1. nv上默认使用torch profiler，同时支持环境变量切换到dipu profiler
2. 其他厂商也会推进接入厂商的profiler api