### PR TITLE
[dicp][ascend] infer op resinfo and run single op 231221

### DIFF
--- a/dicp/dicp/vendor/AscendGraph/ascend_op.py
+++ b/dicp/dicp/vendor/AscendGraph/ascend_op.py
@@ -289,7 +289,7 @@ class Expand(Operator):
     def __init__(self):
         super().__init__("Expand")
 
-    # TODO: unfinished, need furthur test
+    # TODO: unfinished, need furthur test, PASS
     def infer_result(self, x, shape_tensor):
         x, x_shape, x_dim, x_dtype = get_fake_tensor_meta_val(x, True)
         (

--- a/dicp/dicp/vendor/AscendGraph/codegen/load_and_run.py
+++ b/dicp/dicp/vendor/AscendGraph/codegen/load_and_run.py
@@ -237,7 +237,6 @@ class AscendExecutor(object):
 
     def init_resource(self):
         print("init resource stage:")
-
         self.load_model()
         self.num_inputs = acl.mdl.get_num_inputs(self.model_desc)
         self.num_outputs = acl.mdl.get_num_outputs(self.model_desc)
@@ -271,7 +270,7 @@ class AscendExecutor(object):
 
     @record_function('load_and_run_prepare_input')
     def _prepare_input(self, images, dims):
-        assert self.num_inputs == len(images)
+        # assert self.num_inputs == len(images) # for ops like 'empty_like' which has a tensor image but not being real input(in current comprehension)
         for i in range(self.num_inputs):
             buffer_size = self.input_size[i]
             if dims is not None and i in dims.keys():
@@ -344,7 +343,7 @@ class AscendExecutor(object):
     def run(self, images, dims=None, output_shape=None,
             out_stride=None, out_storage_offset=None,
             allocated_output=None):
-        assert len(images) > 0
+        # assert len(images) > 0  # for ops like 'full' which has no images?(in current comprehension)
         input = [x.to(dipu_device_str) if isinstance(x, torch.Tensor)
                  and x.device.type != dipu_device_str else x for x in images]
         allocated_output_tensor = None

--- a/dicp/dicp/vendor/AscendGraph/infer_res_utils.py
+++ b/dicp/dicp/vendor/AscendGraph/infer_res_utils.py
@@ -107,7 +107,6 @@ def get_cast_dtype(
         return int_list[max(t1_idx, t2_idx)]
     elif type1 == torch.bool or type2 == torch.bool:
         return torch.bool
-    
 
     assert False, str(type1) + " " + str(type2) + " can't cast these two types!"
 

--- a/dicp/dicp/vendor/AscendGraph/infer_res_utils.py
+++ b/dicp/dicp/vendor/AscendGraph/infer_res_utils.py
@@ -107,6 +107,7 @@ def get_cast_dtype(
         return int_list[max(t1_idx, t2_idx)]
     elif type1 == torch.bool or type2 == torch.bool:
         return torch.bool
+    
 
     assert False, str(type1) + " " + str(type2) + " can't cast these two types!"
 


### PR DESCRIPTION
fixing ops for generating tensor from specified shape or a tensor like 'full' or 'empty_like' 
the following modification may have underlying effect or may not be the best choice
-  delete some assert in ascend.py and load_and_run.py for special input/output cases in graph transform
-  check and modify the graph inputs for the above ops 