### PR TITLE
remove useless LD_PRELOAD

### DIFF
--- a/dipu/scripts/ci/nv/ci_nv_env.sh
+++ b/dipu/scripts/ci/nv/ci_nv_env.sh
@@ -28,7 +28,6 @@ export PYTORCH_DIR=${PLATFORM}/dep/DIOPI_pytorch/pytorch2.0_cu118
 export LD_LIBRARY_PATH=$DIPU_ROOT:$LD_LIBRARY_PATH
 export PYTHONPATH=${PYTORCH_DIR}:${PYTHONPATH}
 export PATH=${GCC_ROOT}/bin:${CONDA_ROOT}/envs/dipu_poc/bin:${CONDA_ROOT}/bin:${PLATFORM}/dep/binutils-2.27/bin:${PATH}
-export LD_PRELOAD=${GCC_ROOT}/lib64/libstdc++.so.6
 export PYTORCH_TEST_DIR=${PLATFORM}/env/miniconda3.8/envs/pt2.0_diopi/pytorch2.0
 export CUBLAS_WORKSPACE_CONFIG=:4096:8
 


### PR DESCRIPTION
remove useless LD_PRELOAD env, causing trouble

```bash
/mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/bin/gdb: /mnt/cache/share/platform/dep/gcc-10.2/lib64/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by /mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/bin/gdb)
/mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/bin/gdb: /mnt/cache/share/platform/dep/gcc-10.2/lib64/libstdc++.so.6: version `CXXABI_1.3.13' not found (required by /mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/bin/gdb)
```