### PR TITLE
[DIPU] disable custom fallback ops partly.

### DIFF
--- a/dipu/tests/python/individual_scripts/test_dipu_fallback.py
+++ b/dipu/tests/python/individual_scripts/test_dipu_fallback.py
@@ -190,24 +190,6 @@ def _test_dipu_silu_fallback():
         ["custom fallback to cpu, name=silu_out"],
     )
 
-def _test_dipu_linear_fallback():
-    def fn():
-        m = torch.nn.Linear(10, 5).cuda()
-        input_dipu = torch.randn(2, 10).cuda()
-        output_dipu = m(input_dipu)
-
-        m = m.cpu()
-        input_cpu = input_dipu.cpu()
-        output_cpu = m(input_cpu)
-
-        assert torch.allclose(output_dipu.cpu(), output_cpu)
-
-    test_fallback(
-        ["linear"],
-        ["diopiLinear"],
-        fn,
-        ["custom fallback to cpu, name=linear"],
-    )
 
 if __name__ == "__main__":
     run_individual_test_cases(
@@ -218,8 +200,7 @@ if __name__ == "__main__":
             _test_dipu_copy_fallback_,
             _test_dipu_convolution_backward_overrideable_fallback,
             _test_dipu_convolution_overrideable_fallback,
-            _test_dipu_silu_fallback,
-            _test_dipu_linear_fallback,
+            _test_dipu_silu_fallback
         ],
         in_parallel=True,
     )

--- a/dipu/tests/python/individual_scripts/test_dipu_fallback.py
+++ b/dipu/tests/python/individual_scripts/test_dipu_fallback.py
@@ -190,6 +190,24 @@ def _test_dipu_silu_fallback():
         ["custom fallback to cpu, name=silu_out"],
     )
 
+def _test_dipu_linear_fallback():
+    def fn():
+        m = torch.nn.Linear(10, 5).cuda()
+        input_dipu = torch.randn(2, 10).cuda()
+        output_dipu = m(input_dipu)
+
+        m = m.cpu()
+        input_cpu = input_dipu.cpu()
+        output_cpu = m(input_cpu)
+
+        assert torch.allclose(output_dipu.cpu(), output_cpu)
+
+    test_fallback(
+        ["linear"],
+        ["diopiLinear"],
+        fn,
+        ["custom fallback to cpu, name=linear"],
+    )
 
 if __name__ == "__main__":
     run_individual_test_cases(
@@ -201,6 +219,7 @@ if __name__ == "__main__":
             _test_dipu_convolution_backward_overrideable_fallback,
             _test_dipu_convolution_overrideable_fallback,
             _test_dipu_silu_fallback,
+            _test_dipu_linear_fallback,
         ],
         in_parallel=True,
     )

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -65,12 +65,12 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 #define DIOPI_ATEN_FUNC_CUSTOM_FALLBACK(opname, diopi_func, force_fallback,   \
                                         wapper_func, custom_fallback_func)    \
   do {                                                                        \
-    const static std::vector<std::string> disable_custom_fallback_ops_list {  \
-      "linear",                                                               \
+    const static std::vector<std::string> disable_custom_fallback_ops_list{   \
+        "linear",                                                             \
     };                                                                        \
-    auto iter =                                                               \
-      std::find(disable_custom_fallback_ops_list.cbegin(),                    \
-                disable_custom_fallback_ops_list.cend(), std::string(opname));\
+    auto iter = std::find(disable_custom_fallback_ops_list.cbegin(),          \
+                          disable_custom_fallback_ops_list.cend(),            \
+                          std::string(opname));                               \
     const char* env = std::getenv("DIPU_DISABLE_CUSTOM_FALLBACK");            \
     int env_value = (env != nullptr) ? std::atoi(env) : 0;                    \
     if (env_value >= 1 && iter != disable_custom_fallback_ops_list.cend()) {  \

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -48,9 +48,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 // add type trait code. 2. pytorch seems are sorting out infer and other
 // pre/post code. so we shouldn't created a new preprocess logic?
 // so just do a simple runtime cpu fallback to support diopi func loss
+
 // It mat be necessary to determine whether to keep torchop default impl
 // for non-custom ops through function dipuKeepTorchopDefaultImpl firstly in the
-// future.
+// future, and we use force fallback to keep torchop default impl now.
 #define DIOPI_ATEN_FUNC(opname, diopiFunc, wapperFunc)                       \
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -50,7 +50,7 @@ inline void synchronizeIfEnable() {
 }
 
 inline bool dipuKeepTorchopDefaultImpl(const char* opname) {
-  const char* env = std::getenv("DIPU_KEEP_TORCHOP_DEFAULT_IMPL_OPS");
+  static const char* env = std::getenv("DIPU_KEEP_TORCHOP_DEFAULT_IMPL_OPS");
   return (env != nullptr) &&
          ((std::string(env) + ',').find(std::string(opname) + ',') <
           (strlen(env) - 1));

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -49,6 +49,13 @@ inline void synchronizeIfEnable() {
   }
 }
 
+inline bool dipuKeepTorchopDefaultImpl(const char* opname) {
+  const char* env = std::getenv("DIPU_KEEP_TORCHOP_DEFAULT_IMPL_OPS");
+  return (env != nullptr) &&
+         ((std::string(env) + ',').find(std::string(opname) + ',') <
+          (strlen(env) - 1));
+}
+
 inline int dumpOpArgLevel() {
   static const char* env_ptr = std::getenv("DIPU_DUMP_OP_ARGS");
   static int level = env_ptr ? std::atoi(env_ptr) : 0;


### PR DESCRIPTION
**Motivation and Context  背景**

-   由于dipu存在自定义的dispatch逻辑(包括custom_fallback)，影响了dynamo中对meta key的dispatch行为，在linear设为custom_fallback后，会影响linear_backward的dispatch行为。

**Description  描述  功能抽象**

-   通过增设一个环境变量DIPU_DISABLE_CUSTOM_FALLBACK以及disable_custom_fallback_ops_list在必要时禁用custom_fallback的逻辑（默认开启custom_fallback）。

**类别 （Bug 修复|new feature| Intenal SW ）**

- Bug 修复