### PR TITLE
[dipu]add matmul_backward for droplet

### DIFF
--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -1541,6 +1541,19 @@
   device: [droplet]
   interface: diopiMatmul(ctx, out, self, other)
 
+- schema: "matmul_backward(Tensor grad_out, Tensor input, Tensor other, bool[2] mask) -> (Tensor grad_input, Tensor grad_other)"
+  device: [droplet]
+  custom_fallback: True
+  custom_code_at_the_beginning: |
+    at::Tensor grad_input, grad_other;
+    if (mask[0]) {
+      grad_input = at::native::empty_like(input);
+    }
+    if (mask[1]) {
+      grad_other = at::native::empty_like(other);
+    }
+  interface: diopiMatmulBackward(ctx, grad_input, grad_other, grad_out, input, other)
+
 - schema: "cumsum.out(Tensor self, int dim, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)"
   custom_code_at_the_beginning: |
     const auto self_dtype = at::native::to(self, dtype);

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/CustomFallbackFunctions.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/CustomFallbackFunctions.hpp
@@ -300,7 +300,7 @@ static std::tuple<at::Tensor, at::Tensor> custom_fallback_dipu_matmul_backward(
     grad_input =
         at::sum_to(at::matmul(grad_out_cpu, other_cpu.transpose(-1, -2)),
                    input.sizes())
-            .to(device);
+            .to(device, input.dtype());
   }
 
   if (mask[1]) {
@@ -309,7 +309,8 @@ static std::tuple<at::Tensor, at::Tensor> custom_fallback_dipu_matmul_backward(
     if (other.dim() == 1) {
       grad_other_cpu.squeeze_(-1);
     }
-    grad_other = at::sum_to(grad_other_cpu, other.sizes()).to(device);
+    grad_other =
+        at::sum_to(grad_other_cpu, other.sizes()).to(device, other.dtype());
   }
 
   return {grad_input, grad_other};

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/CustomFallbackFunctions.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/CustomFallbackFunctions.hpp
@@ -275,6 +275,46 @@ custom_fallback_dipu_linear_backward(const at::Tensor& input,
   return std::make_tuple(grad_input, grad_weight, grad_bias);
 }
 
+static std::tuple<at::Tensor, at::Tensor> custom_fallback_dipu_matmul_backward(
+    const at::Tensor& grad_out, const at::Tensor& input,
+    const at::Tensor& other, ::std::array<bool, 2> mask) {
+  DIPU_OP_LOG_WARNING_ONCE("custom fallback to cpu, name=matmul_backward\n");
+  auto grad_out_cpu = to_cpu_with_half_to_float(grad_out);
+  auto input_cpu = to_cpu_with_half_to_float(input);
+  auto other_cpu = to_cpu_with_half_to_float(other);
+
+  if (other.dim() == 1) {
+    other_cpu.unsqueeze_(-1);
+    grad_out_cpu.unsqueeze_(-1);
+  }
+
+  if (input.dim() == 1) {
+    input_cpu.unsqueeze_(0);
+    grad_out_cpu.unsqueeze_(-2);
+  }
+
+  const auto device = input.device();
+  at::Tensor grad_input, grad_other;
+
+  if (mask[0]) {
+    grad_input =
+        at::sum_to(at::matmul(grad_out_cpu, other_cpu.transpose(-1, -2)),
+                   input.sizes())
+            .to(device);
+  }
+
+  if (mask[1]) {
+    at::Tensor grad_other_cpu =
+        at::matmul(input_cpu.transpose(-1, -2), grad_out_cpu);
+    if (other.dim() == 1) {
+      grad_other_cpu.squeeze_(-1);
+    }
+    grad_other = at::sum_to(grad_other_cpu, other.sizes()).to(device);
+  }
+
+  return {grad_input, grad_other};
+}
+
 static std::tuple<at::Tensor, at::Tensor, at::Tensor>
 custom_fallback_dipu_native_batch_norm_backward(
     const at::Tensor& grad_out, const at::Tensor& input,


### PR DESCRIPTION
给droplet加一下matmul_backward的注册，这个暂时不太好加测例，我自测了些情况fallback函数是可以正常工作的，diopi应该可以先不更新，或者等那边的合了之后再更新下
diopi对应修改：https://github.com/DeepLink-org/DIOPI/pull/828