### PR TITLE
[DIPU] Check SupportedDiopiFunctions.txt and upgrade to clang17

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -38,7 +38,7 @@ jobs:
       with:
         style: file
         tidy-checks: '-*' # disable clang tidy at this stage
-        version: 16
+        version: 17
     - name: Fail test
       if: steps.cpp-lint.outputs.checks-failed > 0
       run: echo "Some files failed the linting checks!" && exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,10 +257,14 @@ jobs:
     needs: [Build-Cuda]
     runs-on: tps-sco-ci
     steps:
-      - name: clang-tidy
+      - name: Check SupportedDiopiFunctions.txt
         run: |
-          set -eo pipefail
-          srun --job-name=${GITHUB_JOB} bash -c "bash ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh "
+          cd $DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda &&
+            git diff -s --exit-code dipu/SupportedDiopiFunctions.txt ||
+            { echo "::error file=dipu/SupportedDiopiFunctions.txt,title=File Not Match::Please commit your compiled SupportedDiopiFunctions.txt" && exit 1; }
+      - name: Run clang-tidy
+        run: |
+          bash $DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh srun --job-name=$GITHUB_JOB --time=20
 
   Test-Cuda:
     name: Test-dipu-cuda
@@ -318,7 +322,7 @@ jobs:
           set -e
           cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/Build-Cuda/dipu/mmlab_pack
           rm -rf one_iter_data
-          touch one_iter_data   #用于占位，防止创建新的one_iter_data文件夹
+          touch one_iter_data   #用于占位，防止创建新的 one_iter_data 文件夹
       - name: Check for failure
         if: ${{ failure() }}
         run: exit 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -264,7 +264,7 @@ jobs:
             { echo "::error file=dipu/SupportedDiopiFunctions.txt,title=File Not Match::Please commit your compiled SupportedDiopiFunctions.txt" && exit 1; }
       - name: Run clang-tidy
         run: |
-          srun --job-name=$GITHUB_JOB bash "$DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh"
+          srun --job-name=$GITHUB_JOB bash -c "bash $DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh"
 
   Test-Cuda:
     name: Test-dipu-cuda

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -264,6 +264,7 @@ jobs:
             { echo "::error file=dipu/SupportedDiopiFunctions.txt,title=File Not Match::Please commit your compiled SupportedDiopiFunctions.txt" && exit 1; }
       - name: Run clang-tidy
         run: |
+          source /mnt/cache/share/deeplinkci/github/proxy_on
           bash $DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh srun --job-name=$GITHUB_JOB --time=20
 
   Test-Cuda:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -264,8 +264,7 @@ jobs:
             { echo "::error file=dipu/SupportedDiopiFunctions.txt,title=File Not Match::Please commit your compiled SupportedDiopiFunctions.txt" && exit 1; }
       - name: Run clang-tidy
         run: |
-          source /mnt/cache/share/deeplinkci/github/proxy_on &&
-          bash "$DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh" srun --job-name=$GITHUB_JOB
+          srun --job-name=$GITHUB_JOB bash "$DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh"
 
   Test-Cuda:
     name: Test-dipu-cuda

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -264,8 +264,8 @@ jobs:
             { echo "::error file=dipu/SupportedDiopiFunctions.txt,title=File Not Match::Please commit your compiled SupportedDiopiFunctions.txt" && exit 1; }
       - name: Run clang-tidy
         run: |
-          source /mnt/cache/share/deeplinkci/github/proxy_on
-          bash $DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh srun --job-name=$GITHUB_JOB --time=20
+          source /mnt/cache/share/deeplinkci/github/proxy_on &&
+          bash "$DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh" srun --job-name=$GITHUB_JOB
 
   Test-Cuda:
     name: Test-dipu-cuda

--- a/dipu/.clang-tidy
+++ b/dipu/.clang-tidy
@@ -25,7 +25,7 @@ Checks: '
   hicpp-avoid-goto,
   hicpp-exception-baseclass,
   misc-header-include-cycle,
-  misc-include-cleaner,
+  -misc-include-cleaner,
   misc-static-assert,
   misc-unused-alias-decls,
   misc-unused-using-decls,
@@ -40,8 +40,7 @@ Checks: '
   -readability-identifier-length,
   -readability-identifier-naming,
   -readability-qualified-auto,
-  -readability-static-accessed-through-instance',
-  -unused-includes
+  -readability-static-accessed-through-instance'
   # TODO: #446 - enable readability-identifier-naming
   # TODO(c++17) - enable modernize-concat-nested-namespaces
   # TODO(c++17) - enable modernize-use-nodiscard?
@@ -50,7 +49,7 @@ Checks: '
   # TODO(clang17) - enable readability-static-accessed-through-instance
   # TODO(clang17) - enable modernize-type-traits
   # TODO(clang17) - enable performance-avoid-endl
-  # TODO(clang17) - enable unused-includes
+  # TODO(clang17) - enable misc-include-cleaner
 AnalyzeTemporaryDtors: false
 FormatStyle: file
 HeaderFilterRegex: '.*'

--- a/dipu/.clang-tidy
+++ b/dipu/.clang-tidy
@@ -2,8 +2,10 @@
 Checks: '
   bugprone-*,
   -bugprone-easily-swappable-parameters,
+  -bugprone-empty-catch,
   -bugprone-reserved-identifier,
   -bugprone-signed-char-misuse,
+  -bugprone-switch-missing-default-case,
   clang-analyzer-*,
   clang-diagnostic-*,
   cppcoreguidelines-*,
@@ -29,17 +31,26 @@ Checks: '
   misc-unused-using-decls,
   modernize-*,
   -modernize-concat-nested-namespaces,
+  -modernize-type-traits,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   performance-*,
+  -performance-avoid-endl,
   readability-*,
   -readability-identifier-length,
   -readability-identifier-naming,
   -readability-qualified-auto,
-  -readability-static-accessed-through-instance'
+  -readability-static-accessed-through-instance',
+  -unused-includes
   # TODO: #446 - enable readability-identifier-naming
-  # TODO: C++17 - enable modernize-concat-nested-namespaces
-  # TODO: C++17 - enable modernize-use-nodiscard?
+  # TODO(c++17) - enable modernize-concat-nested-namespaces
+  # TODO(c++17) - enable modernize-use-nodiscard?
+  # TODO(clang17) - enable bugprone-empty-catch
+  # TODO(clang17) - enable bugprone-switch-missing-default-case
+  # TODO(clang17) - enable readability-static-accessed-through-instance
+  # TODO(clang17) - enable modernize-type-traits
+  # TODO(clang17) - enable performance-avoid-endl
+  # TODO(clang17) - enable unused-includes
 AnalyzeTemporaryDtors: false
 FormatStyle: file
 HeaderFilterRegex: '.*'

--- a/dipu/.clangd
+++ b/dipu/.clangd
@@ -1,7 +1,5 @@
 CompileFlags:
   Remove: -fabi*
-# Diagnostics:
-  # Available in clangd-14
-  # UnusedIncludes: Strict
-  # Require clangd-17
-  # MissingIncludes: Strict
+Diagnostics:
+  UnusedIncludes: None # Remove it when ready
+  MissingIncludes: None # Remove it when ready

--- a/dipu/SupportedDiopiFunctions.txt
+++ b/dipu/SupportedDiopiFunctions.txt
@@ -114,7 +114,7 @@ diopiHardtanhBackward
 diopiHardtanhInp
 diopiIm2Col
 diopiIndex
-diopiIndexPut
+diopiIndexPutInp
 diopiIndexSelect
 diopiIsNan
 diopiLayerNorm

--- a/dipu/scripts/ci/nv/ci_nv_tidy.sh
+++ b/dipu/scripts/ci/nv/ci_nv_tidy.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-# Try finding clangd and libstdc++.so.6 on sco.
+# Try finding clangd and libstdc++.so.6 on SCO.
 # Note 1: ":+:" is used to handle unbound variable.
 # Note 2: the following code might be outdated.
+[ -f /mnt/cache/share/deeplinkci/github/proxy_on ] &&
+    source /mnt/cache/share/deeplinkci/github/proxy_on
 [ -d /mnt/cache/share/platform/dep/clang-16/bin ] &&
     export PATH=/mnt/cache/share/platform/dep/clang-16/bin${PATH:+:$PATH}
-[ -d /mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/lib ] &&
-    export LD_LIBRARY_PATH=/mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 
 # Required tools.
 [ -x "$(command -v git)" ] || { echo "::error::Missing git tool" && exit 1; }
 [ -x "$(command -v clangd)" ] || { echo "::error::Missing clangd tool" && exit 1; }
 
 # Get current folder.
-self=$(dirname "$(realpath -s "$0")")
+self=$(dirname "$(realpath -s "${BASH_SOURCE[0]}")")
 repo=$(cd "$self" && git rev-parse --show-toplevel)
 
 # Download clangd-tidy scripts.
@@ -24,5 +24,5 @@ repo=$(cd "$self" && git rev-parse --show-toplevel)
 # Forward srun commands.
 # e.g. you can use "bash scripts/ci/nv/ci_nv_tidy.sh srun -p pat_rd" to run tidy.
 (cd "$repo/dipu" &&
-    $@ "$self/clangd-tidy/clangd-tidy" -j4 -v \
-        $(find torch_dipu ! -path '*/vendor/*' ! -name 'AutoGenedKernels.cpp' \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \)))
+    find torch_dipu ! -path '*/vendor/*' ! -name 'AutoGenedKernels.cpp' \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) |
+    xargs "$self/clangd-tidy/clangd-tidy" -j4)

--- a/dipu/scripts/ci/nv/ci_nv_tidy.sh
+++ b/dipu/scripts/ci/nv/ci_nv_tidy.sh
@@ -1,26 +1,28 @@
 #!/bin/bash
 set -euo pipefail
-source /mnt/cache/share/deeplinkci/github/proxy_on
-# Require Git.
-[ -x "$(command -v git)" ] || (echo "missing git tool" && exit 1)
+
+# Try finding clangd and libstdc++.so.6 on 1988.
+# Note 1: ":+:" is used to handle unbound variable.
+# Note 2: the following code might be outdated.
+[ -d /mnt/lustre/share/platform/dep/clang-16/bin ] &&
+    export PATH=/mnt/lustre/share/platform/dep/clang-17/bin${PATH:+:$PATH}
+[ -d /mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/lib ] &&
+    export LD_LIBRARY_PATH=/mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+
+# Required tools.
+[ -x "$(command -v git)" ] || { echo "::error::Missing git tool" && exit 1; }
+[ -x "$(command -v clangd)" ] || { echo "::error::Missing clangd tool" && exit 1; }
 
 # Get current folder.
-self=$(dirname $(realpath -s $0))
-repo=$(cd $self && git rev-parse --show-toplevel)
+self=$(dirname "$(realpath -s "$0")")
+repo=$(cd "$self" && git rev-parse --show-toplevel)
 
 # Download clangd-tidy scripts.
 [ -d "$self/clangd-tidy" ] ||
     git -c advice.detachedHead=false clone --depth 1 -b v0.1.0 https://github.com/lljbash/clangd-tidy.git "$self/clangd-tidy"
 
-# Try finding clangd and libstdc++.so.6 on 1988.
-# Note: ":+:" is used to handle unbound variable.
-[ -d /mnt/cache/share/platform/dep/clang-16/bin ] &&
-    export PATH=/mnt/cache/share/platform/dep/clang-16/bin${PATH:+:$PATH}
-[ -d /mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/lib ] &&
-    export LD_LIBRARY_PATH=/mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-
 # Forward srun commands.
-# e.g. you can use: bash scripts/ci/nv/ci_nv_tidy.sh srun -p pat_rd
+# e.g. you can use "bash scripts/ci/nv/ci_nv_tidy.sh srun -p pat_rd" to run tidy.
 (cd "$repo/dipu" &&
-    (find torch_dipu ! -path '*/vendor/*' ! -name AutoGenedKernels.cpp \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) |
-        xargs $self/clangd-tidy/clangd-tidy -j4))
+    $@ find torch_dipu ! -path '*/vendor/*' ! -name 'AutoGenedKernels.cpp' \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) |
+    xargs "$self/clangd-tidy/clangd-tidy" -j4)

--- a/dipu/scripts/ci/nv/ci_nv_tidy.sh
+++ b/dipu/scripts/ci/nv/ci_nv_tidy.sh
@@ -3,11 +3,10 @@ set -euo pipefail
 
 # Try finding clangd and libstdc++.so.6 on SCO.
 # Note 1: ":+:" is used to handle unbound variable.
-# Note 2: the following code might be outdated.
 [ -f /mnt/cache/share/deeplinkci/github/proxy_on ] &&
     source /mnt/cache/share/deeplinkci/github/proxy_on
-[ -d /mnt/cache/share/platform/dep/clang-16/bin ] &&
-    export PATH=/mnt/cache/share/platform/dep/clang-16/bin${PATH:+:$PATH}
+[ -d /mnt/cache/share/platform/dep/clang-17/bin ] &&
+    export PATH=/mnt/cache/share/platform/dep/clang-17/bin${PATH:+:$PATH}
 
 # Required tools.
 [ -x "$(command -v git)" ] || { echo "::error::Missing git tool" && exit 1; }
@@ -21,8 +20,7 @@ repo=$(cd "$self" && git rev-parse --show-toplevel)
 [ -d "$self/clangd-tidy" ] ||
     git -c advice.detachedHead=false clone --depth 1 -b v0.1.0 https://github.com/lljbash/clangd-tidy.git "$self/clangd-tidy"
 
-# Forward srun commands.
-# e.g. you can use "bash scripts/ci/nv/ci_nv_tidy.sh srun -p pat_rd" to run tidy.
+# Collect source files and run tidy.
 (cd "$repo/dipu" &&
     find torch_dipu ! -path '*/vendor/*' ! -name 'AutoGenedKernels.cpp' \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) |
     xargs "$self/clangd-tidy/clangd-tidy" -j4)

--- a/dipu/scripts/ci/nv/ci_nv_tidy.sh
+++ b/dipu/scripts/ci/nv/ci_nv_tidy.sh
@@ -18,7 +18,7 @@ repo=$(cd "$self" && git rev-parse --show-toplevel)
 
 # Download clangd-tidy scripts.
 [ -d "$self/clangd-tidy" ] ||
-    git -c advice.detachedHead=false clone --depth 1 -b v0.1.0 https://github.com/lljbash/clangd-tidy.git "$self/clangd-tidy"
+    git -c advice.detachedHead=false clone --depth 1 -b v0.1.2 https://github.com/lljbash/clangd-tidy.git "$self/clangd-tidy"
 
 # Collect source files and run tidy.
 (cd "$repo/dipu" &&

--- a/dipu/scripts/ci/nv/ci_nv_tidy.sh
+++ b/dipu/scripts/ci/nv/ci_nv_tidy.sh
@@ -24,5 +24,5 @@ repo=$(cd "$self" && git rev-parse --show-toplevel)
 # Forward srun commands.
 # e.g. you can use "bash scripts/ci/nv/ci_nv_tidy.sh srun -p pat_rd" to run tidy.
 (cd "$repo/dipu" &&
-    $@ find torch_dipu ! -path '*/vendor/*' ! -name 'AutoGenedKernels.cpp' \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) |
-    xargs "$self/clangd-tidy/clangd-tidy" -j4)
+    $@ "$self/clangd-tidy/clangd-tidy" -j4 -v \
+        $(find torch_dipu ! -path '*/vendor/*' ! -name 'AutoGenedKernels.cpp' \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \)))

--- a/dipu/scripts/ci/nv/ci_nv_tidy.sh
+++ b/dipu/scripts/ci/nv/ci_nv_tidy.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# Try finding clangd and libstdc++.so.6 on 1988.
+# Try finding clangd and libstdc++.so.6 on sco.
 # Note 1: ":+:" is used to handle unbound variable.
 # Note 2: the following code might be outdated.
-[ -d /mnt/lustre/share/platform/dep/clang-16/bin ] &&
-    export PATH=/mnt/lustre/share/platform/dep/clang-17/bin${PATH:+:$PATH}
+[ -d /mnt/cache/share/platform/dep/clang-16/bin ] &&
+    export PATH=/mnt/cache/share/platform/dep/clang-16/bin${PATH:+:$PATH}
 [ -d /mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/lib ] &&
     export LD_LIBRARY_PATH=/mnt/cache/share/platform/env/miniconda3.10/envs/pt2.0_diopi/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 


### PR DESCRIPTION
- 在 CI 流程中检查大家是否忘记提交自己的 `SupportedDiopiFunctions.txt` 文件
  - 已测试 `SupportedDiopiFunctions.txt` 不一致时会正常报错
- 试了一下 clang17，这个版本新增了缺少或者多余的头文件的检查（iwyu），挺实用的
  - 目前 clang16 到 clang17 不需要修改代码，我把新增的检查都关了，之后逐渐开放吧
- 顺便优化了一下之前的脚本
  - 移除 subshell
  - 简化部分写法
  - 顺便吐槽一下 git 版本太老了，甚至不支持 `-C` 之类的参数
