### PR TITLE
[DIPU] Use mixed scalar type instead of f32 in group_norm.

### DIFF
--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -257,7 +257,7 @@
 - schema: "native_group_norm(Tensor input, Tensor? weight, Tensor? bias, SymInt N, SymInt C, SymInt HxW, int group, float eps) -> (Tensor, Tensor, Tensor)"
   custom_code_at_the_beginning: |
     auto out0 = at::empty_like(input);
-    auto options = input.options().dtype(at::kFloat);
+    auto options = input.options().dtype(dipu::native::mixed_output_scalar_type(input, weight, bias));
     auto out1 = at::empty({N.expect_int(), group}, options);
     auto out2 = at::empty({N.expect_int(), group}, options);
   interface: diopiGroupNorm(ctx, out0, out1, out2, input, weight, bias, group, eps);

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -245,16 +245,21 @@ auto unwrap_or(T&& x, U&& fallback)
   return std::forward<T>(x).value_or(std::forward<U>(fallback));
 }
 
+template <typename... Tensors>
+bool is_mixed_type(Tensors&&... tensors) {
+  auto is_mixed = at::native::is_mixed_type(std::forward<Tensors>(tensors)...);
+  if (is_mixed) {
+    at::native::check_mixed_data_type(std::forward<Tensors>(tensors)...);
+  }
+  return is_mixed;
+}
+
 template <typename... Args>
 at::ScalarType mixed_output_scalar_type(const at::Tensor& input,
                                         const Args&... parameters) {
-  namespace an = at::native;
   auto static const empty = at::Tensor{};
-  auto mixed = an::is_mixed_type(input, unwrap_or(parameters, empty)...);
-  if (mixed) {
-    an::check_mixed_data_type(input, unwrap_or(parameters, empty)...);
-  }
-  return an::param_scalar_type(input, mixed);
+  auto mixed = is_mixed_type(input, unwrap_or(parameters, empty)...);
+  return at::native::param_scalar_type(input, mixed);
 }
 
 }  // namespace native

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -12,8 +12,10 @@
 #include <ATen/core/Generator.h>
 #include <ATen/core/List.h>
 #include <ATen/core/TensorBody.h>
+#include <ATen/native/cpu/mixed_data_type.h>
 #include <ATen/ops/abs.h>
 #include <ATen/ops/allclose.h>
+#include <c10/core/ScalarType.h>
 #include <c10/util/ArrayRef.h>
 #include <c10/util/Optional.h>
 #include <c10/util/OptionalArrayRef.h>
@@ -229,6 +231,29 @@ inline std::string _allclose(const c10::ArrayRef<at::Tensor>& a,
     result += std::to_string(i) + "th " + _allclose(a[i], b[i]) + "; ";
   }
   return result;
+}
+
+template <typename T>
+inline decltype(auto) unwrap(T& x, T& /* unused */) {
+  return x;
+}
+
+template <typename T, typename U>
+inline auto unwrap(T& x, U& y) -> decltype(x.has_value(), x.value()) {
+  if (x.has_value()) {
+    return x.value();
+  }
+  return y;
+}
+
+template <typename... Args>
+inline at::ScalarType mixed_output_scalar_type(const at::Tensor& input,
+                                               const Args&... parameters) {
+  auto mixed = at::native::is_mixed_type(input, unwrap(parameters, input)...);
+  if (mixed) {
+    at::native::check_mixed_data_type(input, unwrap(parameters, input)...);
+  }
+  return at::native::param_scalar_type(input, mixed);
 }
 
 }  // namespace native

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -245,11 +245,11 @@ auto unwrap_or(T&& x, U&& fallback)
   return std::forward<T>(x).value_or(std::forward<U>(fallback));
 }
 
-template <typename... Tensors>
-bool is_mixed_type(Tensors&&... tensors) {
-  auto is_mixed = at::native::is_mixed_type(std::forward<Tensors>(tensors)...);
+template <typename... T>
+bool is_mixed_type(const T&... tensors) {
+  auto is_mixed = at::native::is_mixed_type(tensors...);
   if (is_mixed) {
-    at::native::check_mixed_data_type(std::forward<Tensors>(tensors)...);
+    at::native::check_mixed_data_type(tensors...);
   }
   return is_mixed;
 }


### PR DESCRIPTION
尝试修复一个问题。当前 GroupNorm 使用了固定的 float32 类型作为均值、方差等返回值，这里复用了 torch 的判断逻辑处理 fp16 及混合精度的类型。

参考：[`mixed_data_type.h`](https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/cpu/mixed_data_type.h)