### PR TITLE
[DICP] add repeat/tril/logical_or/ge for ascendgraph

### DIFF
--- a/dicp/dicp/vendor/AscendGraph/ascend_op.py
+++ b/dicp/dicp/vendor/AscendGraph/ascend_op.py
@@ -909,6 +909,30 @@ class PadV3(Operator):
         super().__init__("PadV3")
 
 
+class LogicalOr(Operator):
+    def __init__(self):
+        super().__init__("LogicalOr")
+
+    def infer_result(self, x1, x2):
+        return common_binary_op_infer(x1, x2, torch.bool)
+
+
+class Tril(Operator):
+    def __init__(self):
+        super().__init__("Tril")
+
+    def infer_result(self, x, diagonal=0):
+        return torch.empty_like(x)
+
+
+class Tile(Operator):
+    def __init__(self):
+        super().__init__("Tile")
+
+    def infer_result(self, x, multiples):
+        return torch.ops.aten.repeat.default(x, multiples)
+
+
 def ret_triple(a, b, c) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     return a, b, c
 

--- a/dicp/dicp/vendor/AscendGraph/codegen/ascend.py
+++ b/dicp/dicp/vendor/AscendGraph/codegen/ascend.py
@@ -1531,3 +1531,24 @@ class AscendOverrides:
         op.set_input("index", index)
         op.set_attr_int("dim", dim)
         return op.to_node()
+
+    @staticmethod
+    def Tril(name, x, diagonal=0):
+        op = OP(name, "Tril")
+        op.set_input("x", x)
+        op.set_attr_int("diagonal", diagonal)
+        return op.to_node()
+
+    @staticmethod
+    def Tile(name, x, multiples):
+        op = OP(name, "TileD")
+        op.set_input("x", x)
+        op.set_attr_list_int("multiples", multiples)
+        return op.to_node()
+
+    @staticmethod
+    def LogicalOr(name, x, y):
+        op = OP(name, "LogicalOr")
+        op.set_input("x1", x)
+        op.set_input("x2", y)
+        return op.to_node()

--- a/dicp/dicp/vendor/AscendGraph/conversion.py
+++ b/dicp/dicp/vendor/AscendGraph/conversion.py
@@ -301,7 +301,7 @@ class AtenToAscendTransformer(SingleOpTransformer):
     def inge(self, x, y):
         if not isinstance(y, torch.fx.proxy.Proxy):
             assert isinstance(y, int)
-            y = self.get_const_proxy(ascend_op.Const, (y, torch.int32))
+            y = self.get_const_proxy(y, torch.int32)
         return self.get_proxy(ascend_op.GreaterEqual, (x, y))
 
     @register_conversion(aten.div)

--- a/dicp/dicp/vendor/AscendGraph/conversion.py
+++ b/dicp/dicp/vendor/AscendGraph/conversion.py
@@ -1268,3 +1268,23 @@ class AtenToAscendTransformer(SingleOpTransformer):
         p = 1. - scale
         prob_op = self.get_const_proxy(float(p), dtype)
         return self.get_proxy(ascend_op.DropOutDoMaskV3, (grad_output, mask, prob_op))
+
+    @register_conversion(torch.ops.aten.tril.default)
+    def Tril(self, x, diagonal=0):
+        return self.get_proxy(ascend_op.Tril, (x, diagonal))
+
+    @register_conversion(torch.ops.aten.repeat.default)
+    def Repeat(self, x, repeats):
+        assert isinstance(repeats, list)
+        return self.get_proxy(ascend_op.Tile, (x, repeats))
+
+    @register_conversion([torch.ops.aten.ge.Scalar, torch.ops.aten.ge.Tensor])
+    def Ge(self, x, y):
+        if not isinstance(y, torch.fx.proxy.Proxy):
+            dtype = x.node.meta['val'].dtype
+            y = self.get_const_proxy(y, dtype)
+        return self.get_proxy(ascend_op.GreaterEqual, (x, y))
+
+    @register_conversion(torch.ops.aten.logical_or.default)
+    def LogicalOr(self, x, y):
+        return self.get_proxy(ascend_op.LogicalOr, (x, y))

--- a/dicp/test/ascend_scripts/ops/static.ini
+++ b/dicp/test/ascend_scripts/ops/static.ini
@@ -27,11 +27,13 @@ python_files =
                test_full_like.py
             ;    test_full.py
                test_gather.py
+               test_ge.py
                test_getitem.py
                test_index.py
                test_le.py
             ;    test_lift_fresh_copy.py
             ;    test_log.py
+               test_logical_or.py
                test_lt.py
                test_masked_fill.py
             ;    test_max_pool2d_with_indices.py
@@ -47,6 +49,7 @@ python_files =
             ;    test_permute.py
                test_pow.py
                test_relu.py
+               test_repeat.py
                test_rsqrt.py
                test_scatter.py
                test_select.py
@@ -57,6 +60,7 @@ python_files =
                test_sub.py
                test_sum.py
             ;    test_transpose.py
+               test_tril.py
                test_unsqueeze.py
                test_view_as_complex.py
                test_view_as_real.py

--- a/dicp/test/op/test_ge.py
+++ b/dicp/test/op/test_ge.py
@@ -1,0 +1,44 @@
+import pytest
+from ..common.utils import (
+    torch,
+    dynamo,
+    parse_args,
+    compile_model,
+    get_device,
+    Size,
+    update_dynamo_config,
+)
+
+
+class OpModule(torch.nn.Module):
+    def forward(self, a, b):
+        res_Tensor = torch.ops.aten.ge.Tensor(a, b)
+        res_Scalar = torch.ops.aten.ge.Scalar(a, 0.0)
+        return res_Tensor, res_Scalar
+
+
+model = OpModule()
+args = parse_args()
+compiled_model = compile_model(model, args.backend, args.dynamic)
+
+
+class TestGe():
+    @pytest.mark.parametrize("dtype", [torch.float32])
+    @pytest.mark.parametrize("sizes", [Size((5,), (5, 3)), Size((3, 5), (5, 3)), Size((2, 3, 4), (2, 4))])
+    @pytest.mark.parametrize("compiled_model", compiled_model)
+    def test_torch_ge(self, sizes, dtype, compiled_model):
+        device = get_device()
+        size = sizes.dynamic if compiled_model.dynamic else sizes.static
+        input1 = torch.randn(size, dtype=dtype)
+        input2 = torch.randn(size, dtype=dtype)
+
+        dicp_input1 = input1.to(device)
+        dicp_input2 = input2.to(device)
+
+        output = model(input1, input2)
+        dynamo.reset()
+        update_dynamo_config(compiled_model.dynamic)
+        dicp_output = compiled_model.model(dicp_input1, dicp_input2)
+
+        for i, item in enumerate(output):
+            assert torch.allclose(item, dicp_output[i].cpu(), equal_nan=True)

--- a/dicp/test/op/test_logical_or.py
+++ b/dicp/test/op/test_logical_or.py
@@ -1,0 +1,41 @@
+import pytest
+from ..common.utils import (
+    torch,
+    dynamo,
+    parse_args,
+    compile_model,
+    get_device,
+    Size,
+    update_dynamo_config,
+)
+
+
+class OpModule(torch.nn.Module):
+    def forward(self, a, b):
+        res = torch.ops.aten.logical_or.default(a, b)
+        return res
+
+
+model = OpModule()
+args = parse_args()
+compiled_model = compile_model(model, args.backend, args.dynamic)
+
+
+class TestLogicalOr():
+    @pytest.mark.parametrize("sizes", [Size((5,), (5, 3)), Size((3, 5), (5, 3)), Size((2, 3, 4), (2, 4))])
+    @pytest.mark.parametrize("compiled_model", compiled_model)
+    def test_torch_logical_or(self, sizes, compiled_model):
+        device = get_device()
+        size = sizes.dynamic if compiled_model.dynamic else sizes.static
+        input1 = torch.randn(size) > 0.5
+        input2 = torch.randn(size) > 0.5
+
+        dicp_input1 = input1.to(device)
+        dicp_input2 = input2.to(device)
+
+        output = model(input1, input2)
+        dynamo.reset()
+        update_dynamo_config(compiled_model.dynamic)
+        dicp_output = compiled_model.model(dicp_input1, dicp_input2)
+
+        assert torch.allclose(output, dicp_output.cpu(), equal_nan=True)

--- a/dicp/test/op/test_tril.py
+++ b/dicp/test/op/test_tril.py
@@ -1,0 +1,42 @@
+import pytest
+from ..common.utils import (
+    torch,
+    dynamo,
+    parse_args,
+    compile_model,
+    get_device,
+    Size,
+    update_dynamo_config,
+)
+
+
+class OpModule(torch.nn.Module):
+    def forward(self, a, diagonal):
+        res = torch.ops.aten.tril.default(a, diagonal=diagonal)
+        return res
+
+
+model = OpModule()
+args = parse_args()
+compiled_model = compile_model(model, args.backend, args.dynamic)
+
+
+class TestTril():
+    @pytest.mark.parametrize("dtype", [torch.float32])
+    @pytest.mark.parametrize("sizes", [Size((3, 5), (5, 3)), Size((2, 3, 4), (2, 4))])
+    @pytest.mark.parametrize("diagonal", [0, 1])
+    @pytest.mark.parametrize("compiled_model", compiled_model)
+    def test_torch_tril(self, sizes, dtype, diagonal, compiled_model):
+        device = get_device()
+        size = sizes.dynamic if compiled_model.dynamic else sizes.static
+        input1 = torch.randn(size, dtype=dtype) if isinstance(size, tuple) else torch.tensor(size, dtype=dtype)
+        diagonal = diagonal if isinstance(diagonal, tuple) else min(diagonal, 0)
+
+        dicp_input1 = input1.to(device)
+
+        output = model(input1, diagonal)
+        dynamo.reset()
+        update_dynamo_config(compiled_model.dynamic)
+        dicp_output = compiled_model.model(dicp_input1, diagonal)
+
+        assert torch.allclose(output, dicp_output.cpu(), equal_nan=True)


### PR DESCRIPTION
### Motivation and Context 背景
在dicp ascend 新增 repeat/tril/ge/logical_or 算子

### Description 描述 功能抽象
在dicp ascend 新增 repeat/tril/ge/logical_or 算子

### 类别 （Bug 修复|new feature| Intenal SW ）
new feature