### PR TITLE
[DIPU] set ACL_RT_OVERFLOW_MODE to INFNAN for Ascend

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/deviceimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/deviceimpl.cpp
@@ -18,7 +18,10 @@ namespace devapis {
 using ascend_deviceId = int32_t;
 thread_local bool setDevFlag = false;
 
-void initializeVendor() { DIPU_CALLACLRT(aclInit(nullptr)); }
+void initializeVendor() {
+  DIPU_CALLACLRT(aclInit(nullptr));
+  DIPU_CALLACLRT(aclrtSetDeviceSatMode(ACL_RT_OVERFLOW_MODE_INFNAN));
+}
 
 void finalizeVendor() { DIPU_CALLACLRT(aclFinalize()); }
 


### PR DESCRIPTION
NAN and INF values on Ascend are not correctly handled as torch.nan and torch.inf since the overflow mode is set to saturation (0) by default.

Setting ACL_RT_OVERFLOW_MODE to INFNAN can resolve this issue, which has been verified on diopi_test.

Example:

Before changes (float16 INF):
```
tensor(65504., device='cuda', dtype=torch.float16)
```
After changes (float16 INF):
```
tensor(inf, device='cuda', dtype=torch.float16)
```