### PR TITLE
fix a bug in linalg_vector_norm

### DIFF
--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -2012,8 +2012,18 @@
 
 - schema: linalg_vector_norm.out(Tensor self, Scalar ord=2, int[1]? dim=None, bool keepdim=False, *, ScalarType? dtype=None, Tensor(a!) out) -> Tensor(a!)
   custom_code_at_the_beginning: |
+    at::Tensor self_;
+      if (dtype.has_value()) {
+        self_ = self.to(*dtype);
+    }
+      else{
+        self_ = self;
+    }
+    ::diopiConstTensorHandle_t selfDiopiTensorHandle_ = dipu::diopi_helper::toDiopiTensorHandle(self_);
+    
     ::diopiSize_t dimDiopiSize = toDiopiSize(dim);
-  interface: diopiNorm(ctx, out, self, ord, dimDiopiSize);
+    
+  interface: diopiNorm(ctx, out, selfDiopiTensorHandle_, ord, dimDiopiSize);
 
 - schema: "floor_(Tensor(a!) self) -> Tensor(a!)"
   interface: diopiFloorInp(ctx, self);


### PR DESCRIPTION
fix a bug in linalg_vector_norm, the dtype was igonred and will cause bug in the following code.
‘’‘
import torch
import torch_dipu
input =  torch.rand(size = (1,768),dtype = torch.half, requires_grad=False,device="cuda")
e = torch.linalg.vector_norm(input, 2.0, [1], True, dtype = torch.float)
’‘’