### PR TITLE
[Ascend] fuj / support bfloat16 dtypes for ascend

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.cpp
@@ -38,9 +38,9 @@ namespace native {
 namespace dipu_aten {
 at::Scalar _local_scalar_dense_dipu(const at::Tensor& self) {
   at::Scalar r;
-  AT_DISPATCH_ALL_TYPES_AND2(
-      at::kHalf, at::kBool, self.scalar_type(), "_local_scalar_dense_dipu",
-      [&] {
+  AT_DISPATCH_ALL_TYPES_AND3(
+      at::kHalf, at::kBool, at::kBFloat16, self.scalar_type(),
+      "_local_scalar_dense_dipu", [&] {
         scalar_t value;
         dipu::DIPUStream stream = dipu::getCurrentDIPUStream();
         MemChecker::instance().check(self);

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/communicatorimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/communicatorimpl.cpp
@@ -23,7 +23,7 @@ static std::map<c10d::ReduceOp, HcclReduceOp> hcclOp = {
 };
 
 // HCCL DataType mapping
-static constexpr std::array<std::pair<at::ScalarType, HcclDataType>, 9>
+static constexpr std::array<std::pair<at::ScalarType, HcclDataType>, 10>
     hcclDataTypes{{
         {at::kByte, HCCL_DATA_TYPE_UINT8},
         {at::kChar, HCCL_DATA_TYPE_INT8},
@@ -34,6 +34,7 @@ static constexpr std::array<std::pair<at::ScalarType, HcclDataType>, 9>
         {at::kFloat, HCCL_DATA_TYPE_FP32},
         {at::kDouble, HCCL_DATA_TYPE_FP64},
         {at::kBool, HCCL_DATA_TYPE_UINT8},
+        {at::kBFloat16, HCCL_DATA_TYPE_BFP16},
     }};
 
 HcclDataType getHcclDataType(const at::ScalarType type) {

--- a/dipu/torch_dipu/dipu/amp.py
+++ b/dipu/torch_dipu/dipu/amp.py
@@ -38,6 +38,8 @@ def set_autocast_dipu_dtype(dtype):
 # bf16 is not supported by default.
 # This function needs to be improved in the future and customized for different device.
 def is_bf16_supported():
+    if dipu.vendor_type == "NPU":
+        return True
     return False
 
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
support bfloat16 dtype

## Description
<!--- Describe your changes in detail. -->
update:
hcclDataTypes definition
_local_scalar_dense_dipu impl
is_bf16_supported impl

