### PR TITLE
fix(dipu): let CMake choose current python in PATH rather than highest version

### DIFF
--- a/dipu/CMakeLists.txt
+++ b/dipu/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.20)
 project(TorchDIPU LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
See also: https://cmake.org/cmake/help/latest/policy/CMP0094.html

close #322