### PR TITLE
[DIPU] Replace the default (memCopyAsync + Sync) strategy with (Sync + memCopySync) for direct memory copy on Ascend

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
@@ -87,8 +87,8 @@ inline int64_t getMemCopyBytes(const at::Tensor& dst, const at::Tensor& src,
   return std::min(srcBytes, dstBytes);
 }
 
-inline void memCopyH2D(const at::Tensor& dst, const at::Tensor& src,
-                       dipu::DIPUStream& stream, int64_t nbytes) {
+inline void memCopyAsyncH2D(const at::Tensor& dst, const at::Tensor& src,
+                            dipu::DIPUStream& stream, int64_t nbytes) {
   void* src_ptr = src.data_ptr();
   void* dst_ptr = dst.data_ptr();
 
@@ -96,8 +96,8 @@ inline void memCopyH2D(const at::Tensor& dst, const at::Tensor& src,
   dipu::devproxy::memCopyH2DAsync(stream.rawstream(), nbytes, dst_ptr, src_ptr);
 }
 
-inline void memCopyD2H(const at::Tensor& dst, const at::Tensor& src,
-                       dipu::DIPUStream& stream, int64_t nbytes) {
+inline void memCopyAsyncD2H(const at::Tensor& dst, const at::Tensor& src,
+                            dipu::DIPUStream& stream, int64_t nbytes) {
   void* src_ptr = src.data_ptr();
   void* dst_ptr = dst.data_ptr();
 
@@ -105,8 +105,8 @@ inline void memCopyD2H(const at::Tensor& dst, const at::Tensor& src,
   dipu::devproxy::memCopyD2HAsync(stream.rawstream(), nbytes, dst_ptr, src_ptr);
 }
 
-inline void memCopyD2D(const at::Tensor& dst, const at::Tensor& src,
-                       dipu::DIPUStream& stream, int64_t nbytes) {
+inline void memCopyAsyncD2D(const at::Tensor& dst, const at::Tensor& src,
+                            dipu::DIPUStream& stream, int64_t nbytes) {
   void* src_ptr = src.data_ptr();
   void* dst_ptr = dst.data_ptr();
 
@@ -117,27 +117,67 @@ inline void memCopyD2D(const at::Tensor& dst, const at::Tensor& src,
                                   src.device().index(), src_ptr);
 }
 
-inline void memCopy(const at::Tensor& dst, const at::Tensor& src,
-                    dipu::DIPUStream& stream, DIPUCopyType copyType,
-                    bool needMemCpSync, bool nonOverlappingAndDense) {
+inline void memCopyAsync(const at::Tensor& dst, const at::Tensor& src,
+                         dipu::DIPUStream& stream, DIPUCopyType copyType,
+                         bool nonOverlappingAndDense) {
   int64_t nbytes = getMemCopyBytes(dst, src, nonOverlappingAndDense);
   switch (copyType) {
     case DIPUCopyType::H2D:
       // src is cpu.
-      memCopyH2D(dst, src, stream, nbytes);
+      memCopyAsyncH2D(dst, src, stream, nbytes);
       break;
     case DIPUCopyType::D2H:
       // dst is cpu.
-      memCopyD2H(dst, src, stream, nbytes);
+      memCopyAsyncD2H(dst, src, stream, nbytes);
       break;
     default:  // device to device
-      memCopyD2D(dst, src, stream, nbytes);
+      memCopyAsyncD2D(dst, src, stream, nbytes);
   }
-  // this sync is different with copy_ non_blocking, it's used inside one copy
-  // op when doing a intermidiate cpu copy after some stream op to guarantee the
-  // cpu copy get correct data.
-  if (needMemCpSync) {
-    dipu::devproxy::syncStream(stream.rawstream());
+}
+
+inline void memCopySyncH2D(const at::Tensor& dst, const at::Tensor& src,
+                           int64_t nbytes) {
+  void* src_ptr = src.data_ptr();
+  void* dst_ptr = dst.data_ptr();
+
+  MemChecker::instance().check(dst);
+  dipu::devproxy::memCopyH2D(nbytes, dst_ptr, src_ptr);
+}
+
+inline void memCopySyncD2H(const at::Tensor& dst, const at::Tensor& src,
+                           int64_t nbytes) {
+  void* src_ptr = src.data_ptr();
+  void* dst_ptr = dst.data_ptr();
+
+  MemChecker::instance().check(src);
+  dipu::devproxy::memCopyD2H(nbytes, dst_ptr, src_ptr);
+}
+
+inline void memCopySyncD2D(const at::Tensor& dst, const at::Tensor& src,
+                           int64_t nbytes) {
+  void* src_ptr = src.data_ptr();
+  void* dst_ptr = dst.data_ptr();
+
+  MemChecker::instance().check(src);
+  MemChecker::instance().check(dst);
+  dipu::devproxy::memCopyD2D(nbytes, dst.device().index(), dst_ptr,
+                             src.device().index(), src_ptr);
+}
+
+inline void memCopySync(const at::Tensor& dst, const at::Tensor& src,
+                        DIPUCopyType copyType, bool nonOverlappingAndDense) {
+  int64_t nbytes = getMemCopyBytes(dst, src, nonOverlappingAndDense);
+  switch (copyType) {
+    case DIPUCopyType::H2D:
+      // src is cpu.
+      memCopySyncH2D(dst, src, nbytes);
+      break;
+    case DIPUCopyType::D2H:
+      // dst is cpu.
+      memCopySyncD2H(dst, src, nbytes);
+      break;
+    default:  // device to device
+      memCopySyncD2D(dst, src, nbytes);
   }
 }
 
@@ -225,7 +265,7 @@ class DIPUCopyInplace : public DIPUCopyBase {
                 << std::endl;
     }
 
-    copyPreProcess(dst, src, non_blocking, curStream);
+    copyPreProcess(dst, src, non_blocking, info);
 
     copyAll(dst, src, non_blocking, info);
 
@@ -234,12 +274,13 @@ class DIPUCopyInplace : public DIPUCopyBase {
 
  protected:
   virtual void copyPreProcess(const at::Tensor& dst, const at::Tensor& src,
-                              bool non_blocking, DIPUStream& curStream) {
+                              bool non_blocking, CopyParamsInfo& info) {
     // recordBeforeCopy
     if (non_blocking) {
-      const bool is_default_stream = dipu::getDefaultDIPUStream() == curStream;
-      tryRecordStream(dst, curStream, is_default_stream);
-      tryRecordStream(src, curStream, is_default_stream);
+      const bool is_default_stream =
+          dipu::getDefaultDIPUStream() == info.curStream_;
+      tryRecordStream(dst, info.curStream_, is_default_stream);
+      tryRecordStream(src, info.curStream_, is_default_stream);
     }
   }
 
@@ -264,7 +305,13 @@ class DIPUCopyInplace : public DIPUCopyBase {
     if (dst.is_view() && src.is_view()) {
       TORCH_CHECK(false, "doDirectMemFill cannot support all view-view copy");
     }
-    memCopy(dst, src, curStream, copyType, needMemCpSync, false);
+
+    memCopyAsync(dst, src, curStream, copyType,
+                 /*nonOverlappingAndDense=*/false);
+
+    if (needMemCpSync) {
+      dipu::devproxy::syncStream(curStream.rawstream());
+    }
   }
 
   // support mem copy between 2 nonOverlappingAndDense tensor with same stride
@@ -276,7 +323,12 @@ class DIPUCopyInplace : public DIPUCopyBase {
       printf("--%-50s %-30s \n", "[copy_]:", "doDirectMemCopy");
     }
 
-    memCopy(dst, src, curStream, copyType, needMemCpSync, true);
+    memCopyAsync(dst, src, curStream, copyType,
+                 /*nonOverlappingAndDense=*/true);
+
+    if (needMemCpSync) {
+      dipu::devproxy::syncStream(curStream.rawstream());
+    }
   }
 
   at::Tensor makeSameStrideTensor(const at::Tensor& src, DIPUStream& curStream,
@@ -517,6 +569,16 @@ class DIPUCopyInplace : public DIPUCopyBase {
     doCpuRelayCopy(dst, src, info.curStream_, non_blocking);
   }
 
+  // This virtual method, which is simply a wrapper of doDirectMemCopy by
+  // default, is only used in copyAll. It keeps all original information
+  // including non_blocking, and is thus suitable for overriding on different
+  // devices for more control of the direct memory copy process
+  virtual void directMemCopy(at::Tensor& dst, const at::Tensor& src,
+                             CopyParamsInfo& info, bool non_blocking) {
+    doDirectMemCopy(dst, src, info.curStream_, info.copyType_,
+                    /*needMemCpSync=*/false);
+  }
+
   // overriding this func is possible but not recommended
   virtual void copyAll(at::Tensor& dst, const at::Tensor& src,
                        bool non_blocking, CopyParamsInfo& info) {
@@ -526,8 +588,7 @@ class DIPUCopyInplace : public DIPUCopyBase {
       info.recomputeTensorsInfo(dst, tmpSrc);
     }
     if (info.directMemCopy_) {
-      doDirectMemCopy(dst, tmpSrc, info.curStream_, info.copyType_,
-                      /*needMemCpSync=*/false);
+      directMemCopy(dst, tmpSrc, info, non_blocking);
       return;
     }
     switch (info.copyType_) {

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendCopyInplace.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendCopyInplace.cpp
@@ -37,7 +37,8 @@ class AscendCopyInplace : public DIPUCopyInpOnDIOPI {
       // According to our benchmark for H2D/D2H synchronous direct memory copy,
       // (Sync + memCopySync) is faster than (memCopyAsync + Sync) on Ascend,
       // so do a memCopySync instead of memCopyAsync here
-      memCopySync(dst, src, info.copyType_, true);
+      memCopy(dst, src, info.curStream_, info.copyType_,
+              /*nonOverlappingAndDense=*/true, /*isSynchronousCopy=*/true);
     } else {
       doDirectMemCopy(dst, src, info.curStream_, info.copyType_,
                       /*needMemCpSync=*/false);

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendCopyInplace.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendCopyInplace.cpp
@@ -11,15 +11,46 @@ class AscendCopyInplace : public DIPUCopyInpOnDIOPI {
   ~AscendCopyInplace() override = default;
 
  protected:
+  void copyPreProcess(const at::Tensor& dst, const at::Tensor& src,
+                      bool non_blocking, CopyParamsInfo& info) override {
+    // recordBeforeCopy
+    if (non_blocking) {
+      const bool is_default_stream =
+          dipu::getDefaultDIPUStream() == info.curStream_;
+      tryRecordStream(dst, info.curStream_, is_default_stream);
+      tryRecordStream(src, info.curStream_, is_default_stream);
+    }
+
+    if (!non_blocking && (DIPUCopyType::H2D == info.copyType_ ||
+                          DIPUCopyType::D2H == info.copyType_)) {
+      // According to our benchmark for H2D/D2H synchronous direct memory copy,
+      // (Sync + memCopySync) is faster than (memCopyAsync + Sync) on Ascend,
+      // So do an advance sync here
+      dipu::devapis::syncStream(info.curStream_.rawstream());
+    }
+  }
+
+  void directMemCopy(at::Tensor& dst, const at::Tensor& src,
+                     CopyParamsInfo& info, bool non_blocking) override {
+    if (!non_blocking && (DIPUCopyType::H2D == info.copyType_ ||
+                          DIPUCopyType::D2H == info.copyType_)) {
+      // According to our benchmark for H2D/D2H synchronous direct memory copy,
+      // (Sync + memCopySync) is faster than (memCopyAsync + Sync) on Ascend,
+      // so do a memCopySync instead of memCopyAsync here
+      memCopySync(dst, src, info.copyType_, true);
+    } else {
+      doDirectMemCopy(dst, src, info.curStream_, info.copyType_,
+                      /*needMemCpSync=*/false);
+    }
+  }
+
   void copyPostProcess(bool non_blocking, const CopyParamsInfo& info,
                        DIPUStream& curStream) override {
-    // TODO(fandaoyi): Refactor to remove duplicated code from different vendors
-    // Ref: https://pytorch.org/docs/stable/generated/torch.Tensor.copy_.html
-    // In d2self cases, non_blocking has no effect.
-    // For other cases, do sync after copy if non_blocking is false.
-    if (!non_blocking && info.copyType_ != DIPUCopyType::D2Self) {
-      dipu::devapis::syncStream(curStream.rawstream());
-    }
+    // In d2self cases, non_blocking has no effect (Ref:
+    // https://pytorch.org/docs/stable/generated/torch.Tensor.copy_.html). In
+    // d2h/h2d cases, the (Sync + memCopySync) strategy is adopted (see the
+    // comments in the above functions copyPreProcess and directMemCopy), so
+    // synchronization is never needed here.
   }
 };
 

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/deviceimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/deviceimpl.cpp
@@ -118,21 +118,18 @@ void freeDevice(void* p) {
 // (synchronous) copy from device to a device
 void memCopyD2D(size_t nbytes, deviceId_t dstDevId, void* dst,
                 deviceId_t srcDevId, const void* src) {
-  syncDevice();
   DIPU_CALLACLRT(
       ::aclrtMemcpy(dst, nbytes, src, nbytes, ACL_MEMCPY_DEVICE_TO_DEVICE));
 }
 
 // (synchronous) copy from host to a device
 void memCopyH2D(size_t nbytes, void* dst, const void* src) {
-  syncDevice();
   DIPU_CALLACLRT(
       ::aclrtMemcpy(dst, nbytes, src, nbytes, ACL_MEMCPY_HOST_TO_DEVICE));
 }
 
 // (synchronous) copy from a device to host
 void memCopyD2H(size_t nbytes, void* dst, const void* src) {
-  syncDevice();
   DIPU_CALLACLRT(
       ::aclrtMemcpy(dst, nbytes, src, nbytes, ACL_MEMCPY_DEVICE_TO_HOST));
 }


### PR DESCRIPTION
According to our benchmark for H2D/D2H synchronous direct memory copy, (Sync + memCopySync) is faster than (memCopyAsync + Sync) on Ascend. Hence we replace the former strategy (the default one) with the latter in this PR.