### PR TITLE
[Ascend] fuj / fix redundant call aclrtSetDevice

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/deviceimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/deviceimpl.cpp
@@ -57,9 +57,19 @@ DIPUDeviceProperties getDeviceProperties(int32_t device_index) {
 
 // set current device given device according to id
 void setDevice(deviceId_t devId) {
-  ascend_deviceId devId_ = static_cast<deviceId_t>(devId);
-  DIPU_CALLACLRT(::aclrtSetDevice(devId_))
-  setDevFlag = true;
+  // if device has not been set, then set to be device: 0
+  auto devIdx = current_device();
+
+  // if devId is -1, device is current_device
+  if (devId == -1) {
+    return;
+  }
+
+  if (devIdx != devId) {
+    ascend_deviceId devId_ = static_cast<deviceId_t>(devId);
+    DIPU_CALLACLRT(::aclrtSetDevice(devId_))
+    setDevFlag = true;
+  }
 }
 
 void resetDevice(deviceId_t devId) { DIPU_CALLACLRT(::aclrtResetDevice(devId)) }


### PR DESCRIPTION
#Motivation
1. remove redundant calling of aclrtSetDevice

#TODO 
A process will try to init all device on the Server, that seems to be inconsistent with the behavior of PyTorch.
<img width="697" alt="Screenshot 2024-03-18 at 16 41 30" src="https://github.com/DeepLink-org/deeplink.framework/assets/131414487/c1a93db6-fbb1-4893-9a27-1260be627abc">
