### PR TITLE
yb/fix autocompare

### DIFF
--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -453,6 +453,7 @@ def create_call_aten_cpu_cpp_function_code_from_config(fun_config):
     opname = re.sub("\.dim_min", "_outf", opname)
     opname = re.sub("\.correction", "", opname)
     opname = re.sub("\.input", "", opname)
+    opname = re.sub("\.dim_IntList", "", opname)
     opname = opname.replace(".", "_")
     opname = opname.split(".")[0]
     if opname[-1] == "_" and len(get_function_return_param_from_schema(schema)) > 0:

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/AutoCompareUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/AutoCompareUtils.hpp
@@ -192,18 +192,18 @@ inline std::string allclose_autocompare(
   return stream.str();
 }
 
-
-template<typename T, std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
-inline std::string allclose_autocompare(T val_expect,  T val_real) {
-    std::ostringstream stream;
-    stream << std::setfill(' ');
-    if(val_expect != val_real) {
-      stream << "not allclose:  expect val is " << val_expect  <<  " but the real val is " << val_real  << std::endl;
-    }
-    else {
-      stream << "allclose" << std::endl;
-    }
-    return stream.str();
+template <typename T,
+          std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
+inline std::string allclose_autocompare(T val_expect, T val_real) {
+  std::ostringstream stream;
+  stream << std::setfill(' ');
+  if (val_expect != val_real) {
+    stream << "not allclose:  expect val is " << val_expect
+           << " but the real val is " << val_real << std::endl;
+  } else {
+    stream << "allclose" << std::endl;
+  }
+  return stream.str();
 }
 
 }  // namespace native

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/AutoCompareUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/AutoCompareUtils.hpp
@@ -194,12 +194,13 @@ inline std::string allclose_autocompare(
 
 template <typename T,
           std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
-inline std::string allclose_autocompare(T val_expect, T val_real) {
+inline std::string allclose_autocompare(T val_expected, T val_real,
+                                        int indentation = 2) {
   std::ostringstream stream;
   stream << std::setfill(' ');
-  if (val_expect != val_real) {
-    stream << "not allclose:  expect val is " << val_expect
-           << " but the real val is " << val_real << std::endl;
+  if (val_expected != val_real) {
+    stream << std::setw(indentation) << "not allclose:  expected val is "
+           << val_expected << " but the real val is " << val_real << std::endl;
   } else {
     stream << "allclose" << std::endl;
   }

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/AutoCompareUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/AutoCompareUtils.hpp
@@ -192,5 +192,19 @@ inline std::string allclose_autocompare(
   return stream.str();
 }
 
+
+template<typename T, std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
+inline std::string allclose_autocompare(T val_expect,  T val_real) {
+    std::ostringstream stream;
+    stream << std::setfill(' ');
+    if(val_expect != val_real) {
+      stream << "not allclose:  expect val is " << val_expect  <<  " but the real val is " << val_real  << std::endl;
+    }
+    else {
+      stream << "allclose" << std::endl;
+    }
+    return stream.str();
+}
+
 }  // namespace native
 }  // namespace dipu


### PR DESCRIPTION
* Fix the  autocompare module. Before this, it will fail to compile. The wrong generated code `at::sum_dim_IntList` should be replaced by `at::sum`.
* Add template function allclose_autocompare whose parameters are arithmetic data types.