### PR TITLE
fix(dipu,vendor,ascend): simple and thread-safe device management

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/deviceimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/deviceimpl.cpp
@@ -31,11 +31,11 @@ thread_local auto g_process_device_id_thread_cache = kDeviceIdUninit;
 // and anyway return the process-level device id
 AscendDeviceId tryInitAndAnywayGetProcessDevice(
     AscendDeviceId ascend_device_id) {
-  static std::atomic global_device_id = kDeviceIdUninit;
+  static std::atomic process_device_id = kDeviceIdUninit;
   auto expectedUninit = kDeviceIdUninit;
-  std::atomic_compare_exchange_strong(&global_device_id, &expectedUninit,
+  std::atomic_compare_exchange_strong(&process_device_id, &expectedUninit,
                                       ascend_device_id);
-  return global_device_id.load();
+  return process_device_id.load();
 }
 
 // If thread-level cache of process-level device id hasn't been initialized,


### PR DESCRIPTION
See also: #682

---

1. 重构，在不改变功能（不支持单进程绑定多卡，强制要求单进程只能绑定单卡，且只能绑定一次）的前提下，更清晰地定义了编程模型，降低了理解难度，便于后期维护。
2. 增强了并发时的线程安全。