### PR TITLE
fix(dipu,python): print device index for cuda tensor

### DIFF
--- a/dipu/.clang-format
+++ b/dipu/.clang-format
@@ -13,7 +13,7 @@ IncludeCategories:
   - Regex:         '^("|<)Python\.h'
     Priority:      50
     CaseSensitive: false
-  - Regex:         '^("|<)(frameobject|structmember)\.h'
+  - Regex:         '^("|<)(descrobject|frameobject|object|structmember)\.h'
     Priority:      50
     SortPriority:  51
     CaseSensitive: false

--- a/dipu/tests/python/unittests/test_python_device.py
+++ b/dipu/tests/python/unittests/test_python_device.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2024, DeepLink.
+import torch
+import torch_dipu
+from torch_dipu.testing._internal.common_utils import TestCase, run_tests
+
+
+class TestAbs(TestCase):
+    def test_cpu(self):
+        a = torch.tensor([1, 2, 3])
+        self.assertEqual(str(a.device), "cpu")
+        self.assertEqual(repr(a.device), "device(type='cpu')")
+        self.assertEqual(str(a), "tensor([1, 2, 3])")
+        self.assertEqual(repr(a), "tensor([1, 2, 3])")
+
+    def test_cuda(self):
+        torch.cuda.set_device(0)
+        a = torch.tensor([1, 2, 3]).cuda()
+        self.assertEqual(str(a.device), "cuda:0")
+        self.assertEqual(repr(a.device), "device(type='cuda', index=0)")
+        self.assertEqual(str(a), "tensor([1, 2, 3], device='cuda:0')")
+        self.assertEqual(repr(a), "tensor([1, 2, 3], device='cuda:0')")
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/dipu/tests/python/unittests/test_python_device.py
+++ b/dipu/tests/python/unittests/test_python_device.py
@@ -4,7 +4,7 @@ import torch_dipu
 from torch_dipu.testing._internal.common_utils import TestCase, run_tests
 
 
-class TestAbs(TestCase):
+class TestPythonDevice(TestCase):
     def test_cpu(self):
         a = torch.tensor([1, 2, 3])
         self.assertEqual(str(a.device), "cpu")
@@ -13,12 +13,13 @@ class TestAbs(TestCase):
         self.assertEqual(repr(a), "tensor([1, 2, 3])")
 
     def test_cuda(self):
-        torch.cuda.set_device(0)
+        device_index = 0  # NOTE: maybe 0 is not available, fix me if this happens
+        torch.cuda.set_device(device_index)
         a = torch.tensor([1, 2, 3]).cuda()
-        self.assertEqual(str(a.device), "cuda:0")
-        self.assertEqual(repr(a.device), "device(type='cuda', index=0)")
-        self.assertEqual(str(a), "tensor([1, 2, 3], device='cuda:0')")
-        self.assertEqual(repr(a), "tensor([1, 2, 3], device='cuda:0')")
+        self.assertEqual(str(a.device), f"cuda:{device_index}")
+        self.assertEqual(repr(a.device), f"device(type='cuda', index={device_index})")
+        self.assertEqual(str(a), f"tensor([1, 2, 3], device='cuda:{device_index}')")
+        self.assertEqual(repr(a), f"tensor([1, 2, 3], device='cuda:{device_index}')")
 
 
 if __name__ == "__main__":

--- a/dipu/torch_dipu/csrc_dipu/binding/patchCsrcDevice.cpp
+++ b/dipu/torch_dipu/csrc_dipu/binding/patchCsrcDevice.cpp
@@ -1,24 +1,22 @@
 // Copyright (c) 2023, DeepLink.
 
 #include <array>
-#include <cstring>
-#include <limits>
+#include <cstdint>
 #include <sstream>
 
-#include <ATen/Device.h>
-#include <c10/util/Exception.h>
+#include <c10/core/Device.h>
+#include <c10/core/DeviceType.h>
 #include <c10/util/Optional.h>
 #include <torch/csrc/Device.h>
 #include <torch/csrc/Exceptions.h>
-#include <torch/csrc/Export.h>
-#include <torch/csrc/python_headers.h>
-#include <torch/csrc/utils/object_ptr.h>
-#include <torch/csrc/utils/pybind.h>
-#include <torch/csrc/utils/python_arg_parser.h>
 #include <torch/csrc/utils/python_numbers.h>
 #include <torch/csrc/utils/python_strings.h>
 
-#include <structmember.h>
+#include <Python.h>
+#include <descrobject.h>
+#include <object.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
 
 #include <csrc_dipu/base/basedef.h>
 
@@ -72,7 +70,7 @@ PyObject* DIPU_THPDevice_repr(THPDevice* self) {
 
 PyObject* DIPU_THPDevice_str(THPDevice* self) {
   std::ostringstream oss;
-  oss << _get_dipu_python_type(self->device);
+  oss << at::Device(_get_dipu_python_type(self->device), self->device.index());
   return THPUtils_packString(oss.str().c_str());
 }
 


### PR DESCRIPTION
Example:
```python
import torch
import torch_dipu

torch.cuda.set_device(0)
a = torch.tensor([1, 2, 3]).cuda()
print(a)
```

Expected output:
```
tensor([1, 2, 3], device='cuda:0')
```

Current output (before this commit):
```
tensor([1, 2, 3], device='cuda')
```