### PR TITLE
feat(dipu,droplet): add error message when tangEventQuery failed

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/vendor/droplet/deviceimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/droplet/deviceimpl.cpp
@@ -136,6 +136,8 @@ EventStatus getEventStatus(deviceEvent_t event) {
     ::tangGetLastError(); /* reset internal error state*/
     return devapis::EventStatus::PENDING;
   } else {
+    printf("call a tangrt function (tangEventQuery) failed. return code=%d",
+           ret);
     throw std::runtime_error("dipu device error");
   }
 }


### PR DESCRIPTION
cannot reuse DIPU_CALLDROPLET due to special handling of NotReady
```cpp
#define DIPU_CALLDROPLET(Expr)                                            \
  {                                                                       \
    tangError_t ret = Expr;                                               \
    if (ret != tangSuccess) {                                             \
      printf("call a tangrt function (%s) failed. return code=%d", #Expr, \
             ret);                                                        \
      throw std::runtime_error("dipu device error");                      \
    }                                                                     \
  }

```