### PR TITLE
ywt/fix: memory leak and precision error

### DIFF
--- a/dipu/torch_dipu/dipu/__init__.py
+++ b/dipu/torch_dipu/dipu/__init__.py
@@ -29,7 +29,6 @@ _is_in_bad_fork = getattr(torch_dipu._C, "_is_in_bad_fork", lambda: False)
 # as "gpu" or "cuda" (mock cuda is another problem)
 # only partially aligned now,
 __all__ = [
-    # resume initialize flag after random generator ready
     # "is_initialized",
     # device
     "can_device_access_peer",

--- a/dipu/torch_dipu/dipu/__init__.py
+++ b/dipu/torch_dipu/dipu/__init__.py
@@ -29,7 +29,6 @@ _is_in_bad_fork = getattr(torch_dipu._C, "_is_in_bad_fork", lambda: False)
 # as "gpu" or "cuda" (mock cuda is another problem)
 # only partially aligned now,
 __all__ = [
-    # "is_initialized",
     # device
     "can_device_access_peer",
     "current_device",
@@ -41,6 +40,7 @@ __all__ = [
     "get_device_properties",
     "get_device_capability",
     "is_available",
+    "is_initialized",
     "set_device",
     "GetDeviceProxy",
     "GetDeviceStaticProxy",


### PR DESCRIPTION
- Fixed a memory leak caused by the continuous increase of the `lazy_call` queue. See `ModelLink_Ascend/ascendspeed/core/tensor_parallel/random.py:_set_cuda_rng_state` for more details
- Fixed a precision error where setting the RNG state was never executed. If not fixed, during the backward checkpoint, the RNG state was not consistent with the forward state.