### PR TITLE
fix(dipu,cuda): add nccl capability check

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/vendor/cuda/communiatorimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/cuda/communiatorimpl.cpp
@@ -3,6 +3,26 @@
 #include <csrc_dipu/common.h>
 #include <csrc_dipu/runtime/device/diclapis.h>
 
+/*** NCCL CAPABILITY CHECK ***/
+
+// from torch/csrc/cuda/nccl.h
+#if defined(__CUDA_BF16_TYPES_EXIST__)
+#define HAS_NCCL_BF16_DATATYPE \
+  ((NCCL_MAJOR > 2) || (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
+#elif defined(USE_ROCM) && (TORCH_HIP_VERSION >= 301)
+#define HAS_NCCL_BF16_DATATYPE 1
+#else
+#define HAS_NCCL_BF16_DATATYPE 0
+#endif
+
+// from torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp
+#if defined(NCCL_MAJOR) && \
+    ((NCCL_MAJOR > 2) || (NCCL_MAJOR == 2) && (NCCL_MINOR >= 10))
+#define NCCL_HAS_AVG 1
+#endif
+
+/*** NCCL CAPABILITY CHECK END ***/
+
 namespace dipu {
 
 namespace devapis {


### PR DESCRIPTION
之前用的两个宏 NCCL_HAS_AVG 和 HAS_NCCL_BF16_DATATYPE 是在 torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp 和 torch/csrc/cuda/nccl.h 中定义的，但是这两个文件都是 torch 的源码，在 dipu 里看不到。所以将这两个宏定义抄到了 dipu 的代码中。