### PR TITLE
zq/reformat auto_compare

### DIFF
--- a/dipu/scripts/autogen_diopi_wrapper/autogen_wrapped_code.sh
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_wrapped_code.sh
@@ -5,17 +5,16 @@
 DIPU_DIR=$(readlink -f $(dirname $(readlink -f "$0"))/../..)
 AUTOGEN_DIOPI_WRAPPER=$DIPU_DIR/scripts/autogen_diopi_wrapper
 
-USE_AUTOCOMPARE=${1:-OFF}
-UsedVendor=${2:-cuda}
-Torch_VERSION=${3:-2.1.0}
-GENERATED_KERNELS_SCRIPT=${4:-$AUTOGEN_DIOPI_WRAPPER/autogen_diopi_wrapper.py}
-GENERATED_KERNELS_CONFIG=${5:-$AUTOGEN_DIOPI_WRAPPER/diopi_functions.yaml}
-GENERATED_KERNELS=${6:-$DIPU_DIR/torch_dipu/csrc_dipu/aten/ops/AutoGenedKernels.cpp}
+UsedVendor=${1:-cuda}
+Torch_VERSION=${2:-2.1.0}
+GENERATED_KERNELS_SCRIPT=${3:-$AUTOGEN_DIOPI_WRAPPER/autogen_diopi_wrapper.py}
+GENERATED_KERNELS_CONFIG=${4:-$AUTOGEN_DIOPI_WRAPPER/diopi_functions.yaml}
+GENERATED_KERNELS=${5:-$DIPU_DIR/torch_dipu/csrc_dipu/aten/ops/AutoGenedKernels.cpp}
 
 GENERATED_KERNELS_VENDOR=${DIPU_DIR}/third_party/DIOPI/impl/${UsedVendor}/convert_config.yaml
 
 PYTHON_CMD="python3 ${GENERATED_KERNELS_SCRIPT} --out=${GENERATED_KERNELS} --config=${GENERATED_KERNELS_CONFIG} \
-    --autocompare=${USE_AUTOCOMPARE} --print_op_arg=True --use_diopi_adapter=False --print_func_call_info=True \
+    --print_op_arg=True --use_diopi_adapter=False --print_func_call_info=True \
     --fun_config_dict='{\"current_device\":\"${UsedVendor}\",\"current_torch_ver\":\"${Torch_VERSION}\"}'"
 
 if [ -f "$GENERATED_KERNELS_VENDOR" ]; then

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
@@ -171,12 +171,14 @@ $cppsignautre {
   std::cout << std::endl << __FUNCTION__ << std::endl;
   $transform_input_to_cpu_code
 
-  $execute_op_on_cpu_code
-
   $execute_op_on_device_code
+  
+  if (useAutoCompare()) {
+    $execute_op_on_cpu_code
 
-  $transform_result_to_cpu_code
+    $transform_result_to_cpu_code
 
-  $result_compare_code
+    $result_compare_code
+  }
 }
 """

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -1,5 +1,4 @@
 #[[ Dependencies ]]
-option(USE_AUTOCOMPARE "whether to use USE_AUTOCOMPARE" OFF)
 
 # Import Python3::Python, Python3_EXECUTABLE
 # Also see https://cmake.org/cmake/help/latest/module/FindPython3.html
@@ -58,7 +57,7 @@ endif()
 
 add_custom_command(
   OUTPUT "${GENERATED_KERNELS}"
-  COMMAND bash -c "${AUTOGEN_CODE_SH} ${USE_AUTOCOMPARE} ${UsedVendor} ${Torch_VERSION} ${GENERATED_KERNELS_SCRIPT} ${GENERATED_KERNELS_CONFIG} ${GENERATED_KERNELS}"
+  COMMAND bash -c "${AUTOGEN_CODE_SH} ${UsedVendor} ${Torch_VERSION} ${GENERATED_KERNELS_SCRIPT} ${GENERATED_KERNELS_CONFIG} ${GENERATED_KERNELS}"
   COMMENT "Generating ${GENERATED_KERNELS}$<$<BOOL:${GENERATED_KERNELS_VENDOR}>: with ${GENERATED_KERNELS_VENDOR}>"
   DEPENDS
     "${GENERATED_KERNELS_SCRIPT}"

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -85,6 +85,27 @@ inline int dumpOpArgLevel() {
   return level;
 }
 
+inline bool useAutoCompare() {
+  static const char* autocomparePtr = std::getenv("USE_AUTOCOMPARE");
+  if (autocomparePtr == nullptr) {
+    return false;
+  }
+
+  std::string autocompareString(autocomparePtr);
+  for(char& c : autocompareString) {
+    c = std::tolower(c);
+  }
+
+  if (autocompareString == "on") {
+    return true;
+  } else if (autocompareString == "off") {
+    return false;
+  } else {
+    std::cerr << "Error: USE_AUTOCOMPARE can only be set to 'ON' or 'OFF'." << std::endl;
+    return false;
+  }
+}
+
 template <typename T>
 std::string dumpArg(const T& t) {
   std::stringstream stream;


### PR DESCRIPTION
Reformat auto_compare to utilize environment variable AUTO_COMPARE for switching, eliminating the need for recompilation.

The followings is the autogened  wrapped code:
<img width="959" alt="image" src="https://github.com/DeepLink-org/deeplink.framework/assets/100055343/f0ab7a0f-3dad-4e67-a4bb-bfccfb2b21ca">
