### PR TITLE
Zq/add specified autocompare

### DIFF
--- a/dipu/QuickStart.md
+++ b/dipu/QuickStart.md
@@ -185,10 +185,10 @@ python -c "import torch_dipu"
 
 由于该功能默认不开启，使用该功能时需要打开该功能并重新编译DIPU。
 
-可以通过设置环境变量USE_AUTOCOMPARE=ON，来开启该功能，然后需要重新编译DIPU。
+可以通过设置环境变量USE_GLOBAL_AUTOCOMPARE=ON，来开启该功能，然后需要重新编译DIPU。
 
 ```shell
-export USE_AUTOCOMPARE=ON
+export USE_GLOBAL_AUTOCOMPARE=ON
 ```
 
 以上方法是对所有算子开启自动精度对比。如果只需要对特定算子做精度对比，也可只给需要的算子做精度对比，只需要在相关的配置文件（如 `dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml`）给相应的算子添加 `autocompare: True` 即可。

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -9,6 +9,7 @@ from diopi_wrapper_template import (
     diopi_wrapper_file_template_content,
     diopi_wrapper_function_template_content,
     op_register_template_content,
+    op_register_disable_autocompare_template_content,
     custom_autograd_template_content,
     autocompare_template_content,
     op_with_custom_fallback_register_template_content,
@@ -673,6 +674,10 @@ fun_template = CodeTemplate(diopi_wrapper_function_template_content)
 
 op_register_template = CodeTemplate(op_register_template_content)
 
+op_disable_autocompare_register_template = CodeTemplate(
+    op_register_disable_autocompare_template_content
+)
+
 op_with_custom_fallback_register_template = CodeTemplate(
     op_with_custom_fallback_register_template_content
 )
@@ -940,32 +945,35 @@ def functions_code_gen(fun_config):
             ],
         )
         fbody += autocompare_code
-        fun_name = auto_compare_fun_name
 
-    if fun_config.get("custom_fallback", False) in ["False", False]:
-        op_name = get_op_name_from_schema(fun_config["schema"])
-        raw_fun_name = fun_name.replace("_autocompare", "")
+    # generate the OP_register code
+    if fun_config.get("custom_fallback", False) in ["False", False] and fun_config.get(
+        "autocompare", True
+    ) in ["True", True]:
         register_body = op_register_template.substitute(
-            register_name=[op_name],
-            aten_fun_name=[
-                "dipu::whetherAutoCompare("
-                +'"'
-                + op_name
-                +'"'
-                + ", autocompareMatchers"
-                + ") ? "
-                + "dipu::native::"
-                + fun_name
-                + " : "
-                + "dipu::native::"
-                + raw_fun_name
-            ],
+            register_name=[get_op_name_from_schema(fun_config["schema"])],
+            aten_fun_name=["dipu::native::" + fun_name],
             diopi_fun_name=[
                 get_fun_name_from_cppsignature(diopi_interface).replace(
                     "diopi", "::diopi"
                 )
             ],
         )
+
+    elif fun_config.get("custom_fallback", False) in [
+        "False",
+        False,
+    ] and fun_config.get("autocompare") in ["disable"]:
+        register_body = op_disable_autocompare_register_template.substitute(
+            register_name=[get_op_name_from_schema(fun_config["schema"])],
+            aten_fun_name=["dipu::native::" + fun_name],
+            diopi_fun_name=[
+                get_fun_name_from_cppsignature(diopi_interface).replace(
+                    "diopi", "::diopi"
+                )
+            ],
+        )
+
     else:
         register_body = op_with_custom_fallback_register_template.substitute(
             register_name=[get_op_name_from_schema(fun_config["schema"])],
@@ -988,6 +996,7 @@ def functions_code_gen(fun_config):
                 + fun_name.replace("_autocompare", "")
             ],
         )
+
     return fbody, register_body
 
 

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -906,7 +906,7 @@ def functions_code_gen(fun_config):
         fbody += custom_autograd_function_code
         fun_name = wrapper_fun_name
 
-    if fun_config.get("autocompare", False) in [True, "True"] and fun_config.get(
+    if fun_config.get("autocompare") not in ["disable"] and fun_config.get(
         "register_op", True
     ) in [True, "True"]:
         auto_compare_fun_name = fun_name + "_autocompare"
@@ -1038,12 +1038,6 @@ def parse_args():
         default=False,
         type=boolean_string,
         help="whether generate code that prints op args",
-    )
-    parser.add_argument(
-        "--autocompare",
-        default=False,
-        type=boolean_string,
-        help="whether generate code that compare device calculation results with cpu calculation results",
     )
     parser.add_argument(
         "--fun_config_dict",

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -943,9 +943,23 @@ def functions_code_gen(fun_config):
         fun_name = auto_compare_fun_name
 
     if fun_config.get("custom_fallback", False) in ["False", False]:
+        op_name = get_op_name_from_schema(fun_config["schema"])
+        raw_fun_name = fun_name.replace("_autocompare", "")
         register_body = op_register_template.substitute(
-            register_name=[get_op_name_from_schema(fun_config["schema"])],
-            aten_fun_name=["dipu::native::" + fun_name],
+            register_name=[op_name],
+            aten_fun_name=[
+                "dipu::whetherAutoCompare("
+                +'"'
+                + op_name
+                +'"'
+                + ", autocompareMatchers"
+                + ") ? "
+                + "dipu::native::"
+                + fun_name
+                + " : "
+                + "dipu::native::"
+                + raw_fun_name
+            ],
             diopi_fun_name=[
                 get_fun_name_from_cppsignature(diopi_interface).replace(
                     "diopi", "::diopi"

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_wrapped_code.sh
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_wrapped_code.sh
@@ -5,17 +5,16 @@
 DIPU_DIR=$(readlink -f $(dirname $(readlink -f "$0"))/../..)
 AUTOGEN_DIOPI_WRAPPER=$DIPU_DIR/scripts/autogen_diopi_wrapper
 
-USE_AUTOCOMPARE=${1:-OFF}
-UsedVendor=${2:-cuda}
-Torch_VERSION=${3:-2.1.0}
-GENERATED_KERNELS_SCRIPT=${4:-$AUTOGEN_DIOPI_WRAPPER/autogen_diopi_wrapper.py}
-GENERATED_KERNELS_CONFIG=${5:-$AUTOGEN_DIOPI_WRAPPER/diopi_functions.yaml}
-GENERATED_KERNELS=${6:-$DIPU_DIR/torch_dipu/csrc_dipu/aten/ops/AutoGenedKernels.cpp}
+UsedVendor=${1:-cuda}
+Torch_VERSION=${2:-2.1.0}
+GENERATED_KERNELS_SCRIPT=${3:-$AUTOGEN_DIOPI_WRAPPER/autogen_diopi_wrapper.py}
+GENERATED_KERNELS_CONFIG=${4:-$AUTOGEN_DIOPI_WRAPPER/diopi_functions.yaml}
+GENERATED_KERNELS=${5:-$DIPU_DIR/torch_dipu/csrc_dipu/aten/ops/AutoGenedKernels.cpp}
 
 GENERATED_KERNELS_VENDOR=${DIPU_DIR}/third_party/DIOPI/impl/${UsedVendor}/convert_config.yaml
 
 PYTHON_CMD="python3 ${GENERATED_KERNELS_SCRIPT} --out=${GENERATED_KERNELS} --config=${GENERATED_KERNELS_CONFIG} \
-    --autocompare=${USE_AUTOCOMPARE} --print_op_arg=True --use_diopi_adapter=False --print_func_call_info=True \
+    --print_op_arg=True --use_diopi_adapter=False --print_func_call_info=True \
     --fun_config_dict='{\"current_device\":\"${UsedVendor}\",\"current_torch_ver\":\"${Torch_VERSION}\"}'"
 
 if [ -f "$GENERATED_KERNELS_VENDOR" ]; then

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
@@ -132,6 +132,10 @@ op_register_template_content = """
 DIOPI_ATEN_FUNC("$register_name", $diopi_fun_name, $aten_fun_name);
 """
 
+op_register_disable_autocompare_template_content = """
+DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE("$register_name", $diopi_fun_name, $aten_fun_name);
+"""
+
 op_with_custom_fallback_register_template_content = """
 DIOPI_ATEN_FUNC_CUSTOM_FALLBACK("$register_name", $diopi_fun_name, $force_fallback /*whether force fallback*/, $aten_fun_name, $fallbackFunc);
 """

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
@@ -50,6 +50,7 @@ diopi_wrapper_file_template_content = """// autogened file
 #include "csrc_dipu/aten/ops/DIPUCopy.hpp"
 #include "csrc_dipu/aten/ops/NodispatchUtils.hpp"
 #include "csrc_dipu/aten/ops/OpUtils.hpp"
+#include "csrc_dipu/aten/ops/OpRegexMatch.hpp"
 #include "csrc_dipu/base/basedef.h"
 #include "csrc_dipu/diopirt/diopirt_impl.h"
 #include "csrc_dipu/profiler/profiler.h"

--- a/dipu/scripts/ci/ascend/ci_ascend_script.sh
+++ b/dipu/scripts/ci/ascend/ci_ascend_script.sh
@@ -12,8 +12,8 @@ function build_diopi_lib() {
 function config_dipu_ascend_cmake() {
     mkdir -p build && cd ./build
     cmake_args="-DCMAKE_BUILD_TYPE=Release -DDEVICE=ascend -DWITH_DIOPI_LIBRARY=DISABLE"
-    if [ -n "$USE_AUTOCOMPARE" ]; then
-        cmake_args+=" -DUSE_AUTOCOMPARE=${USE_AUTOCOMPARE}"
+    if [ -n "$USE_GLOBAL_AUTOCOMPARE" ]; then
+        cmake_args+=" -DUSE_GLOBAL_AUTOCOMPARE=${USE_GLOBAL_AUTOCOMPARE}"
     fi
     cmake ../ $cmake_args
     cd ../
@@ -22,8 +22,8 @@ function config_dipu_ascend_cmake() {
 function config_all_ascend_cmake() {
     mkdir -p build && cd ./build
     cmake_args="-DCMAKE_BUILD_TYPE=Release -DDEVICE=ascend -DENABLE_COVERAGE=${USE_COVERAGE} -DWITH_DIOPI=INTERNAL"
-    if [ -n "$USE_AUTOCOMPARE" ]; then
-        cmake_args+=" -DUSE_AUTOCOMPARE=${USE_AUTOCOMPARE}"
+    if [ -n "$USE_GLOBAL_AUTOCOMPARE" ]; then
+        cmake_args+=" -DUSE_GLOBAL_AUTOCOMPARE=${USE_GLOBAL_AUTOCOMPARE}"
     fi
     cmake ../ $cmake_args
     cd ../

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -75,6 +75,7 @@ set(TORCH_DIPU_SOURCE
   aten/ops/PinMemoryKernel.cpp
   aten/ops/EmptyOpsKernel.cpp
   aten/ops/CustomFallbackFunctionsForCopy.cpp
+  aten/ops/OpRegexMatch.cpp
   aten/RegisterDIPU.cpp
   aten/CPUFallback.cpp
 

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -1,5 +1,4 @@
 #[[ Dependencies ]]
-option(USE_AUTOCOMPARE "whether to use USE_AUTOCOMPARE" OFF)
 
 # Import Python3::Python, Python3_EXECUTABLE
 # Also see https://cmake.org/cmake/help/latest/module/FindPython3.html
@@ -58,7 +57,7 @@ endif()
 
 add_custom_command(
   OUTPUT "${GENERATED_KERNELS}"
-  COMMAND bash -c "${AUTOGEN_CODE_SH} ${USE_AUTOCOMPARE} ${UsedVendor} ${Torch_VERSION} ${GENERATED_KERNELS_SCRIPT} ${GENERATED_KERNELS_CONFIG} ${GENERATED_KERNELS}"
+  COMMAND bash -c "${AUTOGEN_CODE_SH} ${UsedVendor} ${Torch_VERSION} ${GENERATED_KERNELS_SCRIPT} ${GENERATED_KERNELS_CONFIG} ${GENERATED_KERNELS}"
   COMMENT "Generating ${GENERATED_KERNELS}$<$<BOOL:${GENERATED_KERNELS_VENDOR}>: with ${GENERATED_KERNELS_VENDOR}>"
   DEPENDS
     "${GENERATED_KERNELS_SCRIPT}"

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
@@ -23,9 +23,8 @@ namespace dnative = dipu::native::dipu_aten;
 namespace dipu {
 namespace {
 
-std::vector<std::regex> load_fallback_matcher() {
-  auto constexpr env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
-  auto constexpr file_name = ".dipu_force_fallback_op_list.config";
+// load_matcher is used to get regex matcher from env_name and config
+std::vector<std::regex> load_matcher(const char* env_name, const char* config_name) {
 
   auto append = [](std::istream& input, std::vector<std::regex>& output) {
     auto constexpr separator = ',';
@@ -52,13 +51,15 @@ std::vector<std::regex> load_fallback_matcher() {
     auto iss = std::istringstream(env);
     append(iss, list);
   }
-  if (auto file = std::ifstream(file_name, std::ios::binary)) {
+  if (auto file = std::ifstream(config_name, std::ios::binary)) {
     append(file, list);
   }
   return list;
 }
 
-auto const force_fallback_matchers = load_fallback_matcher();
+const char*  fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
+const char*  fallback_config_name = ".dipu_force_fallback_op_list.config";
+auto const force_fallback_matchers = load_matcher(fallback_env_name, fallback_config_name);
 
 }  // end of namespace
 

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -47,14 +47,15 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 // for non-custom ops through function dipuKeepTorchopDefaultImpl firstly in the
 // future, and we use force fallback to keep torchop default impl now.
 #define addAutoCompare(wrapperFunc) wrapperFunc##_autocompare
-#define DIOPI_ATEN_FUNC(opname, diopiFunc, wrapperFunc)                       \
+#define DIOPI_ATEN_FUNC(opname, diopiFunc, wrapperFunc)                      \
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
         (!dipu::whetherOpMatch(opname, fallbackMatchers))) {                 \
-      if (dipu::whetherAutoCompare(opname, autocompareMatchers)) {           \
-        m.impl(opname, TORCH_FN(addAutoCompare(wrapperFunc)));                \
+      if (dipu::whetherAutoCompare(opname, autocompareMatchers)) {  \
+        m.impl(opname, TORCH_FN(addAutoCompare(wrapperFunc)));               \
+      } else {                                                               \
+        m.impl(opname, TORCH_FN(wrapperFunc));                               \
       }                                                                      \
-      m.impl(opname, TORCH_FN(wrapperFunc));                                  \
     } else {                                                                 \
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
         DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "); \
@@ -66,11 +67,11 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
     }                                                                        \
   } while (false);
 
-#define DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE(opname, diopiFunc, wrapperFunc)   \
+#define DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE(opname, diopiFunc, wrapperFunc)  \
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
-        (!dipu::whetherOpMatch(opname, fallbackMatchers))) {                  \
-      m.impl(opname, TORCH_FN(wrapperFunc));                                  \
+        (!dipu::whetherOpMatch(opname, fallbackMatchers))) {                 \
+      m.impl(opname, TORCH_FN(wrapperFunc));                                 \
     } else {                                                                 \
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
         DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "); \

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -9,15 +9,9 @@
 #include <torch/library.h>
 
 #include "csrc_dipu/aten/ops/OpUtils.hpp"
-
-namespace dipu {
-
-bool get_force_fallback(const char* opname);
-
-};  // namespace dipu
+#include "csrc_dipu/aten/ops/OpRegexMatch.hpp"
 
 namespace at {
-
 void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
                    torch::jit::Stack* stack);
 
@@ -55,7 +49,7 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 #define DIOPI_ATEN_FUNC(opname, diopiFunc, wapperFunc)                       \
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
-        (!dipu::get_force_fallback(opname))) {                               \
+        (!dipu::whetherOpMatch(opname, fallbackMatchers))) {                               \
       m.impl(opname, TORCH_FN(wapperFunc));                                  \
     } else {                                                                 \
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
@@ -77,7 +71,7 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       break;                                                                  \
     }                                                                         \
     if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                   \
-        !((force_fallback) || dipu::get_force_fallback(opname))) {            \
+        !((force_fallback) || dipu::whetherOpMatch(opname, fallbackMatchers))) {            \
       m.impl(opname, TORCH_FN(wapper_func));                                  \
     } else {                                                                  \
       if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {                 \

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -84,10 +84,8 @@ bool whetherAutoCompare(const char* opname, std::vector<std::regex> autocompareM
     return true;
   } 
   // else if opname in SPECIFIED_AUTOCOMPARE_OPS_LIST, the specified op will be autocomapred
-  // return whetherOpMatch(opname, autocompareMatchers);
-  return false;
-
-}
+  return whetherOpMatch(opname, autocompareMatchers);
+  }
 } // end of namespace dipu
 
 const char*  fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -1,0 +1,99 @@
+#include <algorithm>
+#include <ios>
+#include <iostream>
+#include <fstream>
+#include <regex>
+
+#include <c10/util/Exception.h>
+
+#include "OpRegexMatch.hpp"
+
+// loadMatcher is used to get regex matcher from env_name and config
+// fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST"; fallback_config_name = ".dipu_force_fallback_op_list.config"
+// specified_autocompare_env_name = "SPECIFIED_AUTOCOMPARE_OPS_LIST"; specified_autocompare_config_name = ".specified_autocompare_op_list.config"
+
+namespace dipu {
+std::vector<std::regex> loadMatcher(const char* env_name, const char* config_name) {
+  auto append = [](std::istream& input, std::vector<std::regex>& output) {
+    auto constexpr separator = ',';
+
+    auto line = std::string();
+    while (std::getline(input, line)) {
+      auto buffer = std::istringstream(line);
+      auto pattern = std::string();
+      while (std::getline(buffer, pattern, separator)) {
+        if (pattern.empty()) {
+          continue;
+        }
+        try {
+          output.emplace_back(pattern);
+        } catch (const std::regex_error& e) {
+          TORCH_CHECK(false, e.what());
+        }
+      }
+    }
+  };
+
+  auto list = std::vector<std::regex>();
+  if (auto env = std::getenv(env_name)) {
+    auto iss = std::istringstream(env);
+    append(iss, list);
+  }
+  if (auto file = std::ifstream(config_name, std::ios::binary)) {
+    append(file, list);
+  }
+  return list;
+}
+
+bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers) {
+  if (regexMatchers.empty() || opname == nullptr) {
+    return false;
+  }
+
+  return std::any_of(
+      regexMatchers.begin(), regexMatchers.end(),
+      [&opname](auto& matcher) { return std::regex_match(opname, matcher); });
+}
+
+bool whetherGlobalAutocompare() {
+  static const char* globalAutocompare = std::getenv("USE_GLOBAL_AUTOCOMPARE");
+  if (globalAutocompare == nullptr) {
+    return false;
+  }
+
+  std::string globalAutocompareStr(globalAutocompare);
+  for (char& c : globalAutocompareStr) {
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+
+  if (globalAutocompareStr == "on") {
+    return true;
+  }
+  if (globalAutocompareStr == "off") {
+    return false;
+  }
+
+  std::cerr << "Error: USE_GLOBAL_AUTOCOMPARE can only be set to 'ON' or 'OFF'.\n";
+  return false;
+}
+
+// Whether to enable AutoCompare is based on USE_GLOBAL_AUTOCOMPARE and SPECIFIED_AUTOCOMPARE_OPS_LIST
+bool whetherAutoCompare(const char* opname, std::vector<std::regex> autocompareMatchers) {
+  // if USE_GLOBAL_AUTOCOMPARE is true, global autocompare is enabled regardless the value of SPECIFIED_AUTOCOMPARE_OPS_LIST
+  if (whetherGlobalAutocompare()) {
+    return true;
+  } 
+  // else if opname in SPECIFIED_AUTOCOMPARE_OPS_LIST, the specified op will be autocomapred
+  // return whetherOpMatch(opname, autocompareMatchers);
+  return false;
+
+}
+} // end of namespace dipu
+
+const char*  fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
+const char*  fallback_config_name = ".dipu_force_fallback_op_list.config";
+std::vector<std::regex> fallbackMatchers = dipu::loadMatcher(fallback_env_name, fallback_config_name);
+
+const char* specified_autocompare_env_name = "SPECIFIED_AUTOCOMPARE_OPS_LIST"; 
+const char* specified_autocompare_config_name = ".specified_autocompare_op_list.config";
+std::vector<std::regex> autocompareMatchers = dipu::loadMatcher(specified_autocompare_env_name, specified_autocompare_config_name);

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -1,0 +1,21 @@
+#include <algorithm>
+#include <ios>
+#include <iostream>
+#include <regex>
+
+#include <c10/util/Exception.h>
+
+namespace dipu{
+std::vector<std::regex> loadMatcher(const char* env_name, const char* config_name);
+const bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers);
+bool whetherGlobalAutocompare();
+bool whetherAutoCompare(const char* opname, std::vector<std::regex> autocompareMatchers);
+}
+
+extern const char*  fallback_env_name;
+extern const char*  fallback_config_name;
+extern std::vector<std::regex> fallbackMatchers;
+
+extern const char* specified_autocompare_env_name; 
+extern const char* specified_autocompare_config_name;
+extern std::vector<std::regex> autocompareMatchers;

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -7,7 +7,7 @@
 
 namespace dipu{
 std::vector<std::regex> loadMatcher(const char* env_name, const char* config_name);
-const bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers);
+bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers);
 bool whetherGlobalAutocompare();
 bool whetherAutoCompare(const char* opname, std::vector<std::regex> autocompareMatchers);
 }


### PR DESCRIPTION
重构autocompare，使用环境变量USE_GLOBAL_AUTOCOMPARE和SPECIFIED_AUTOCOMPARE_OPS_LIST来设置autocompare功能，可以设置全局的autocompare和指定算子进行autocompare