### PR TITLE
Zq/add specified autocompare2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -353,21 +353,6 @@ jobs:
           source scripts/ci/ascend/ci_ascend_env.sh
           bash scripts/ci/ascend/ci_ascend_script.sh build_dipu \
           || ( cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf ${GITHUB_JOB} && exit 1 )
-  
-  Build-Ascend-910b-with-autocompare:
-    name: Build-dipu-ascend-910b-with-autocompare
-    needs: [Build-PyTorch-For-Ascend-910b]
-    runs-on: tps-ascend-ci-910b
-    steps:
-      - name: Build dipu
-        run: |
-          set -ex
-          export USE_COVERAGE=ON
-          export USE_AUTOCOMPARE=ON
-          cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf ${GITHUB_JOB} && cp -R source ${GITHUB_JOB}  && cd ${GITHUB_JOB}/dipu
-          source scripts/ci/ascend/ci_ascend_env.sh
-          bash scripts/ci/ascend/ci_ascend_script.sh build_dipu \
-          || ( cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf ${GITHUB_JOB} && exit 1 )
 
   Test-Ascend-910b:
     name: Test-dipu-ascend-910b

--- a/dipu/QuickStart.md
+++ b/dipu/QuickStart.md
@@ -158,7 +158,8 @@ sh ./tests/python/run_tests.sh
 
 ### 算子库拓展功能
 
-#### 算子Fallback功能 
+#### 算子Fallback功能
+
 Fallback指的是使用算子的CPU实现，而非设备实现。  
 Fallback给定算子：
 
@@ -182,7 +183,9 @@ python -c "import torch_dipu"
 ```
 
 #### 算子精度自动对比功能
+
 算子精度自动对比功能用于确保算子计算结果的正确性，通过将设备参数拷贝到CPU上，对比CPU和设备的计算结果来判断精度是否达标。以下是算子精度自动对比功能的使用例子：
+
 ```shell
 $ unset  DIPU_FORCE_FALLBACK_OPS_LIST # 主要是确保要比较的算子没有强制 fallback到CPU, 可选
 $ python
@@ -213,8 +216,11 @@ autocompare:    add.out other: allclose
 可以看到，输出包括 CPU 和设备计算结果的 `shape`、`stride`、`dtype` 等信息， 最终结果是CPU和设备的self和out都是allclose的。
 
 ##### 算子精度自动对比功能的设置
+
 算子精度自动对比功能默认不开启，可以设置环境变量`USE_GLOBAL_AUTOCOMPARE`和`SPECIFIED_AUTOCOMPARE_OPS_LIST`来控制该功能，在开启算子自动对比功能前，必须unset  `DIPU_FORCE_FALLBACK_OPS_LIST`
+
 - 可以通过设置环境变量`USE_GLOBAL_AUTOCOMPARE=ON`，开启全局的精度对比，这种情况下所有调用的算子都会进行精度对比，也可以设置为OFF来关闭所有算子的精度自动对比功能
+
 ```shell
 # 开启全局的算子精度自动对比功能
 export USE_GLOBAL_AUTOCOMPARE=ON
@@ -228,7 +234,8 @@ export USE_GLOBAL_AUTOCOMPARE=OFF
 export SPECIFIED_AUTOCOMPARE_OPS_LIST=add*
 ```
 
-NOTE: 
+NOTE:
+
 1. 部分算子并不支持自动精度对比功能，可以查看[diopi_functions.yaml](https://github.com/DeepLink-org/deeplink.framework/blob/main/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml)，其中的`autocompare`配置项为`disable`即不支持自动精度对比功能，同时也可以修改`diopi_functions.yaml`，将某些算子的`autocompare`配置项设置为`disable`来禁用自动对比功能。
 2. `dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml` 中配置了 `autograd:True` 的算子 (`cross_entropy_loss`、`conv2d`、`dropout`、`dropout_`、`linear`) 暂不支持 *backward* 的精度自动对比。如模型精度对不齐，可根据需要先将这几个算子 fallback 到 CPU 来确定问题。
 3. 对输入参数(self)做检查是确保算子的输入不被意外修改。

--- a/dipu/QuickStart.md
+++ b/dipu/QuickStart.md
@@ -184,10 +184,11 @@ python -c "import torch_dipu"
 
 #### 算子精度自动对比功能
 
-算子精度自动对比功能用于确保算子计算结果的正确性，通过将设备参数拷贝到CPU上，对比CPU和设备的计算结果来判断精度是否达标。以下是算子精度自动对比功能的使用例子：
+算子精度自动对比功能(autocompare)用于确保算子计算结果的正确性，通过将设备参数拷贝到CPU上，对比CPU和设备的计算结果来判断精度是否达标。以下是算子精度自动对比功能的使用例子：
 
 ```shell
 $ unset  DIPU_FORCE_FALLBACK_OPS_LIST # 主要是确保要比较的算子没有强制 fallback到CPU, 可选
+$ export DIPU_AUTOCOMPARE_OPS_LIST=add.out # 对add.out算子开启autocompare功能
 $ python
 >>> import torch
 >>> import torch_dipu
@@ -217,21 +218,22 @@ autocompare:    add.out other: allclose
 
 ##### 算子精度自动对比功能的设置
 
-算子精度自动对比功能默认不开启，可以设置环境变量`USE_GLOBAL_AUTOCOMPARE`和`SPECIFIED_AUTOCOMPARE_OPS_LIST`来控制该功能，在开启算子自动对比功能前，必须unset  `DIPU_FORCE_FALLBACK_OPS_LIST`
+算子精度自动对比功能默认不开启，可以设置环境变量`DIPU_AUTOCOMPARE_OPS_LIST`来控制该功能，在开启算子自动对比功能前，必须unset  `DIPU_FORCE_FALLBACK_OPS_LIST`
 
-- 可以通过设置环境变量`USE_GLOBAL_AUTOCOMPARE=ON`，开启全局的精度对比，这种情况下所有调用的算子都会进行精度对比，也可以设置为OFF来关闭所有算子的精度自动对比功能
+- 可以通过设置环境变量`SPECIFIED_AUTOCOMPARE_OPS_LIST=‘.*’`，开启全局的精度对比，这种情况下所有调用的算子都会进行精度对比。
 
 ```shell
 # 开启全局的算子精度自动对比功能
-export USE_GLOBAL_AUTOCOMPARE=ON
+export SPECIFIED_AUTOCOMPARE_OPS_LIST=‘.*’
 ```
 
-- 在未开启`USE_GLOBAL_AUTOCOMPARE`的前提下，可以设置`SPECIFIED_AUTOCOMPARE_OPS_LIST`来指定算子开启自动精度对比，支持正则表达式匹配。算子名可以参考[diopi_functions.yaml](https://github.com/DeepLink-org/deeplink.framework/blob/main/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml)。
+- 可以设置`DIPU_AUTOCOMPARE_OPS_LIST`来指定算子开启自动精度对比，支持正则表达式匹配，也可以指定多个算子开启自动精度对比。算子名可以参考[diopi_functions.yaml](https://github.com/DeepLink-org/deeplink.framework/blob/main/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml)。
 
 ```shell
-# 关闭全局的算子精度自动对比功能，并指定add.*?算子进行对比
-export USE_GLOBAL_AUTOCOMPARE=OFF
-export SPECIFIED_AUTOCOMPARE_OPS_LIST=add.*?
+# 指定匹配add.*?的算子进行自动精度对比
+export DIPU_AUTOCOMPARE_OPS_LIST=add.*?
+# 指定add.out、sub.out算子进行自动精度对比
+export DIPU_AUTOCOMPARE_OPS_LIST="add.out, sub.out"
 ```
 
 NOTE:

--- a/dipu/QuickStart.md
+++ b/dipu/QuickStart.md
@@ -220,11 +220,11 @@ autocompare:    add.out other: allclose
 
 算子精度自动对比功能默认不开启，可以设置环境变量`DIPU_AUTOCOMPARE_OPS_LIST`来控制该功能，在开启算子自动对比功能前，必须unset  `DIPU_FORCE_FALLBACK_OPS_LIST`
 
-- 可以通过设置环境变量`DIPU_AUTOCOMPARE_OPS_LIST=‘.*’`，开启全局的精度对比，这种情况下所有调用的算子都会进行精度对比。
+- 可以通过设置环境变量`DIPU_AUTOCOMPARE_OPS_LIST='.*'`，开启全局的精度对比，这种情况下所有调用的算子都会进行精度对比。
 
 ```shell
 # 开启全局的算子精度自动对比功能
-export DIPU_AUTOCOMPARE_OPS_LIST=‘.*’
+export DIPU_AUTOCOMPARE_OPS_LIST='.*'
 ```
 
 - 可以设置`DIPU_AUTOCOMPARE_OPS_LIST`来指定算子开启自动精度对比，支持正则表达式匹配，也可以指定多个算子开启自动精度对比。算子名可以参考[diopi_functions.yaml](https://github.com/DeepLink-org/deeplink.framework/blob/main/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml)。

--- a/dipu/QuickStart.md
+++ b/dipu/QuickStart.md
@@ -229,9 +229,9 @@ export USE_GLOBAL_AUTOCOMPARE=ON
 - 在未开启`USE_GLOBAL_AUTOCOMPARE`的前提下，可以设置`SPECIFIED_AUTOCOMPARE_OPS_LIST`来指定算子开启自动精度对比，支持正则表达式匹配。算子名可以参考[diopi_functions.yaml](https://github.com/DeepLink-org/deeplink.framework/blob/main/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml)。
 
 ```shell
-# 关闭全局的算子精度自动对比功能，并指定add*算子进行对比
+# 关闭全局的算子精度自动对比功能，并指定add.*?算子进行对比
 export USE_GLOBAL_AUTOCOMPARE=OFF
-export SPECIFIED_AUTOCOMPARE_OPS_LIST=add*
+export SPECIFIED_AUTOCOMPARE_OPS_LIST=add.*?
 ```
 
 NOTE:

--- a/dipu/QuickStart.md
+++ b/dipu/QuickStart.md
@@ -185,10 +185,10 @@ python -c "import torch_dipu"
 
 由于该功能默认不开启，使用该功能时需要打开该功能并重新编译DIPU。
 
-可以通过设置环境变量USE_AUTOCOMPARE=ON，来开启该功能，然后需要重新编译DIPU。
+可以通过设置环境变量USE_GLOBAL_AUTOCOMPARE=ON，来开启该功能，然后需要重新编译DIPU。
 
 ```shell
-export USE_AUTOCOMPARE=ON
+export USE_GLOBAL_AUTOCOMPARE=ON
 ```
 
 以上方法是对所有算子开启自动精度对比。如果只需要对特定算子做精度对比，也可只给需要的算子做精度对比，只需要在相关的配置文件（如 `dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml`）给相应的算子添加 `autocompare: True` 即可。

--- a/dipu/QuickStart.md
+++ b/dipu/QuickStart.md
@@ -220,11 +220,11 @@ autocompare:    add.out other: allclose
 
 算子精度自动对比功能默认不开启，可以设置环境变量`DIPU_AUTOCOMPARE_OPS_LIST`来控制该功能，在开启算子自动对比功能前，必须unset  `DIPU_FORCE_FALLBACK_OPS_LIST`
 
-- 可以通过设置环境变量`SPECIFIED_AUTOCOMPARE_OPS_LIST=‘.*’`，开启全局的精度对比，这种情况下所有调用的算子都会进行精度对比。
+- 可以通过设置环境变量`DIPU_AUTOCOMPARE_OPS_LIST=‘.*’`，开启全局的精度对比，这种情况下所有调用的算子都会进行精度对比。
 
 ```shell
 # 开启全局的算子精度自动对比功能
-export SPECIFIED_AUTOCOMPARE_OPS_LIST=‘.*’
+export DIPU_AUTOCOMPARE_OPS_LIST=‘.*’
 ```
 
 - 可以设置`DIPU_AUTOCOMPARE_OPS_LIST`来指定算子开启自动精度对比，支持正则表达式匹配，也可以指定多个算子开启自动精度对比。算子名可以参考[diopi_functions.yaml](https://github.com/DeepLink-org/deeplink.framework/blob/main/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml)。

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -9,6 +9,7 @@ from diopi_wrapper_template import (
     diopi_wrapper_file_template_content,
     diopi_wrapper_function_template_content,
     op_register_template_content,
+    op_register_disable_autocompare_template_content,
     custom_autograd_template_content,
     autocompare_template_content,
     op_with_custom_fallback_register_template_content,
@@ -673,6 +674,10 @@ fun_template = CodeTemplate(diopi_wrapper_function_template_content)
 
 op_register_template = CodeTemplate(op_register_template_content)
 
+op_disable_autocompare_register_template = CodeTemplate(
+    op_register_disable_autocompare_template_content
+)
+
 op_with_custom_fallback_register_template = CodeTemplate(
     op_with_custom_fallback_register_template_content
 )
@@ -940,32 +945,35 @@ def functions_code_gen(fun_config):
             ],
         )
         fbody += autocompare_code
-        fun_name = auto_compare_fun_name
 
-    if fun_config.get("custom_fallback", False) in ["False", False]:
-        op_name = get_op_name_from_schema(fun_config["schema"])
-        raw_fun_name = fun_name.replace("_autocompare", "")
+    # generate the OP_register code
+    if fun_config.get("custom_fallback", False) in ["False", False] and fun_config.get(
+        "autocompare", True
+    ) in ["True", True]:
         register_body = op_register_template.substitute(
-            register_name=[op_name],
-            aten_fun_name=[
-                "dipu::whetherAutoCompare("
-                +'"'
-                + op_name
-                +'"'
-                + ", autocompareMatchers"
-                + ") ? "
-                + "dipu::native::"
-                + fun_name
-                + " : "
-                + "dipu::native::"
-                + raw_fun_name
-            ],
+            register_name=[get_op_name_from_schema(fun_config["schema"])],
+            aten_fun_name=["dipu::native::" + fun_name],
             diopi_fun_name=[
                 get_fun_name_from_cppsignature(diopi_interface).replace(
                     "diopi", "::diopi"
                 )
             ],
         )
+
+    elif fun_config.get("custom_fallback", False) in [
+        "False",
+        False,
+    ] and fun_config.get("autocompare") in ["disable"]:
+        register_body = op_disable_autocompare_register_template.substitute(
+            register_name=[get_op_name_from_schema(fun_config["schema"])],
+            aten_fun_name=["dipu::native::" + fun_name],
+            diopi_fun_name=[
+                get_fun_name_from_cppsignature(diopi_interface).replace(
+                    "diopi", "::diopi"
+                )
+            ],
+        )
+
     else:
         register_body = op_with_custom_fallback_register_template.substitute(
             register_name=[get_op_name_from_schema(fun_config["schema"])],
@@ -988,6 +996,7 @@ def functions_code_gen(fun_config):
                 + fun_name.replace("_autocompare", "")
             ],
         )
+
     return fbody, register_body
 
 

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -947,6 +947,7 @@ def functions_code_gen(fun_config):
         fbody += autocompare_code
 
     # generate the OP_register code
+    # case 1: custom_fallback=False and autocompare not disabled
     if fun_config.get("custom_fallback", False) in ["False", False] and fun_config.get(
         "autocompare", True
     ) in ["True", True]:
@@ -960,6 +961,7 @@ def functions_code_gen(fun_config):
             ],
         )
 
+    # case2: custom_fallback=False and autocompare=disable
     elif fun_config.get("custom_fallback", False) in [
         "False",
         False,
@@ -973,8 +975,8 @@ def functions_code_gen(fun_config):
                 )
             ],
         )
-
-    else:
+    # case3: custom_fallback=True
+    elif fun_config.get("custom_fallback", False) in ["True", True]:
         register_body = op_with_custom_fallback_register_template.substitute(
             register_name=[get_op_name_from_schema(fun_config["schema"])],
             aten_fun_name=["dipu::native::" + fun_name],

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -948,6 +948,7 @@ def functions_code_gen(fun_config):
 
     # generate the OP_register code
     # case 1: custom_fallback=False and autocompare not disabled
+    register_body = ""
     if fun_config.get("custom_fallback", False) in ["False", False] and fun_config.get(
         "autocompare", True
     ) in ["True", True]:
@@ -975,8 +976,10 @@ def functions_code_gen(fun_config):
                 )
             ],
         )
-    # case3: custom_fallback=True
-    elif fun_config.get("custom_fallback", False) in ["True", True]:
+    # case3: custom_fallback=True and autocompare not disable
+    elif fun_config.get("custom_fallback", False) in ["True", True] and fun_config.get(
+        "autocompare", True
+    ) in ["True", True]:
         register_body = op_with_custom_fallback_register_template.substitute(
             register_name=[get_op_name_from_schema(fun_config["schema"])],
             aten_fun_name=["dipu::native::" + fun_name],
@@ -992,11 +995,7 @@ def functions_code_gen(fun_config):
                     else "true"
                 )
             ],
-            fallbackFunc=[
-                "dipu::native::"
-                + "custom_fallback_"
-                + fun_name.replace("_autocompare", "")
-            ],
+            fallbackFunc=["dipu::native::" + "custom_fallback_" + fun_name],
         )
 
     return fbody, register_body

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -906,7 +906,7 @@ def functions_code_gen(fun_config):
         fbody += custom_autograd_function_code
         fun_name = wrapper_fun_name
 
-    if fun_config.get("autocompare", False) in [True, "True"] and fun_config.get(
+    if fun_config.get("autocompare") not in ["disable"] and fun_config.get(
         "register_op", True
     ) in [True, "True"]:
         auto_compare_fun_name = fun_name + "_autocompare"
@@ -1038,12 +1038,6 @@ def parse_args():
         default=False,
         type=boolean_string,
         help="whether generate code that prints op args",
-    )
-    parser.add_argument(
-        "--autocompare",
-        default=False,
-        type=boolean_string,
-        help="whether generate code that compare device calculation results with cpu calculation results",
     )
     parser.add_argument(
         "--fun_config_dict",

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -943,9 +943,23 @@ def functions_code_gen(fun_config):
         fun_name = auto_compare_fun_name
 
     if fun_config.get("custom_fallback", False) in ["False", False]:
+        op_name = get_op_name_from_schema(fun_config["schema"])
+        raw_fun_name = fun_name.replace("_autocompare", "")
         register_body = op_register_template.substitute(
-            register_name=[get_op_name_from_schema(fun_config["schema"])],
-            aten_fun_name=["dipu::native::" + fun_name],
+            register_name=[op_name],
+            aten_fun_name=[
+                "dipu::whetherAutoCompare("
+                +'"'
+                + op_name
+                +'"'
+                + ", autocompareMatchers"
+                + ") ? "
+                + "dipu::native::"
+                + fun_name
+                + " : "
+                + "dipu::native::"
+                + raw_fun_name
+            ],
             diopi_fun_name=[
                 get_fun_name_from_cppsignature(diopi_interface).replace(
                     "diopi", "::diopi"

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_wrapped_code.sh
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_wrapped_code.sh
@@ -5,17 +5,16 @@
 DIPU_DIR=$(readlink -f $(dirname $(readlink -f "$0"))/../..)
 AUTOGEN_DIOPI_WRAPPER=$DIPU_DIR/scripts/autogen_diopi_wrapper
 
-USE_AUTOCOMPARE=${1:-OFF}
-UsedVendor=${2:-cuda}
-Torch_VERSION=${3:-2.1.0}
-GENERATED_KERNELS_SCRIPT=${4:-$AUTOGEN_DIOPI_WRAPPER/autogen_diopi_wrapper.py}
-GENERATED_KERNELS_CONFIG=${5:-$AUTOGEN_DIOPI_WRAPPER/diopi_functions.yaml}
-GENERATED_KERNELS=${6:-$DIPU_DIR/torch_dipu/csrc_dipu/aten/ops/AutoGenedKernels.cpp}
+UsedVendor=${1:-cuda}
+Torch_VERSION=${2:-2.1.0}
+GENERATED_KERNELS_SCRIPT=${3:-$AUTOGEN_DIOPI_WRAPPER/autogen_diopi_wrapper.py}
+GENERATED_KERNELS_CONFIG=${4:-$AUTOGEN_DIOPI_WRAPPER/diopi_functions.yaml}
+GENERATED_KERNELS=${5:-$DIPU_DIR/torch_dipu/csrc_dipu/aten/ops/AutoGenedKernels.cpp}
 
 GENERATED_KERNELS_VENDOR=${DIPU_DIR}/third_party/DIOPI/impl/${UsedVendor}/convert_config.yaml
 
 PYTHON_CMD="python3 ${GENERATED_KERNELS_SCRIPT} --out=${GENERATED_KERNELS} --config=${GENERATED_KERNELS_CONFIG} \
-    --autocompare=${USE_AUTOCOMPARE} --print_op_arg=True --use_diopi_adapter=False --print_func_call_info=True \
+    --print_op_arg=True --use_diopi_adapter=False --print_func_call_info=True \
     --fun_config_dict='{\"current_device\":\"${UsedVendor}\",\"current_torch_ver\":\"${Torch_VERSION}\"}'"
 
 if [ -f "$GENERATED_KERNELS_VENDOR" ]; then

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -2768,7 +2768,7 @@
 
 - schema: _amp_foreach_non_finite_check_and_unscale_(at::TensorList self, Tensor(b!) found_inf, Tensor inv_scale) -> void
   autocompare: disable
-  # TODO(someone): fix this issue when `autocompare` is on
+  # TODO(zhangqiu): fix this issue when `autocompare` is on
   custom_fallback: True
   custom_code_at_the_beginning: |
     std::vector<diopiTensorHandle_t> diopiTensorHandles(self.size(), nullptr);

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -2768,6 +2768,7 @@
 
 - schema: _amp_foreach_non_finite_check_and_unscale_(at::TensorList self, Tensor(b!) found_inf, Tensor inv_scale) -> void
   autocompare: disable
+  # TODO(someone): fix this issue when `autocompare` is on
   custom_fallback: True
   custom_code_at_the_beginning: |
     std::vector<diopiTensorHandle_t> diopiTensorHandles(self.size(), nullptr);
@@ -2778,8 +2779,6 @@
     });
     // NOLINTEND(cppcoreguidelines-pro-type-const-cast)
   interface: diopiAmpForeachNonFiniteCheckAndUnscaleInp(ctx, diopiTensorHandles.data(), static_cast<int64_t>(self.size()), found_inf, inv_scale)
-  # TODO(someone): fix this issue when `autocompare` is on
-  autocompare: disable
 
 - schema: _amp_update_scale_(Tensor(a!) self, Tensor(b!) growth_tracker, Tensor found_inf, float scale_growth_factor, float scale_backoff_factor, int growth_interval) -> Tensor(a!)
   custom_fallback: True

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -2748,7 +2748,6 @@
 
 # this copy_ aten op may use both diopiCastDtype and diopiCopyInp. it's a proxy/composite op
 - schema: copy_(Tensor(a!) self, Tensor src, bool non_blocking=False) -> Tensor(a!)
-  autocompare: disable
   dummy_call_diopi: True
   custom_fallback: True
   device: [cuda, camb, ascend, droplet, supa, kunlunxin]
@@ -2760,7 +2759,6 @@
 
 # vendor who has no fully implemented diopi and proper fallback DIPUCopy sub-class
 - schema: copy_(Tensor(a!) self, Tensor src, bool non_blocking=False) -> Tensor(a!)
-  autocompare: disable
   custom_fallback: True
   dummy_call_diopi: True
   custom_code_at_the_beginning: |

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -2766,9 +2766,7 @@
   device: [topsrider]
   interface: diopiCopyInp(ctx, src, self)
 
-- schema: _amp_foreach_non_finite_check_and_unscale_(at::TensorList self, Tensor(b!) found_inf, Tensor inv_scale) -> void
-  autocompare: disable
-  # TODO(zhangqiu): fix this issue when `autocompare` is on
+- schema: _amp_foreach_non_finite_check_and_unscale_(at::TensorList self, Tensor(b!) found_inf, Tensor inv_scale) -> ()
   custom_fallback: True
   custom_code_at_the_beginning: |
     std::vector<diopiTensorHandle_t> diopiTensorHandles(self.size(), nullptr);

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
@@ -129,7 +129,7 @@ $cppsignautre {
 """
 
 op_no_fallback_with_autocompare_register_template_content = """
-NO_FALLBACK_with_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $aten_fun_name);
+NO_FALLBACK_WITH_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $aten_fun_name);
 """
 
 op_no_fallback_no_autocompare_register_template_content = """

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
@@ -132,6 +132,10 @@ op_register_template_content = """
 DIOPI_ATEN_FUNC("$register_name", $diopi_fun_name, $aten_fun_name);
 """
 
+op_register_disable_autocompare_template_content = """
+DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE("$register_name", $diopi_fun_name, $aten_fun_name);
+"""
+
 op_with_custom_fallback_register_template_content = """
 DIOPI_ATEN_FUNC_CUSTOM_FALLBACK("$register_name", $diopi_fun_name, $force_fallback /*whether force fallback*/, $aten_fun_name, $fallbackFunc);
 """

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
@@ -128,16 +128,20 @@ $cppsignautre {
 }
 """
 
-op_register_template_content = """
-DIOPI_ATEN_FUNC("$register_name", $diopi_fun_name, $aten_fun_name);
+op_no_fallback_with_autocompare_register_template_content = """
+NO_FALLBACK_with_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $aten_fun_name);
 """
 
-op_register_disable_autocompare_template_content = """
-DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE("$register_name", $diopi_fun_name, $aten_fun_name);
+op_no_fallback_no_autocompare_register_template_content = """
+NO_FALLBACK_NO_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $aten_fun_name);
 """
 
-op_with_custom_fallback_register_template_content = """
-DIOPI_ATEN_FUNC_CUSTOM_FALLBACK("$register_name", $diopi_fun_name, $force_fallback /*whether force fallback*/, $aten_fun_name, $fallbackFunc);
+op_with_fallback_with_autocompare_register_template_content = """
+WITH_FALLBACK_WITH_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $force_fallback /*whether force fallback*/, $aten_fun_name, $fallbackFunc);
+"""
+
+op_with_fallback_no_autocompare_register_template_content = """
+WITH_FALLBACK_NO_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $force_fallback /*whether force fallback*/, $aten_fun_name, $fallbackFunc);
 """
 
 custom_autograd_template_content = """

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
@@ -128,20 +128,20 @@ $cppsignautre {
 }
 """
 
-op_no_fallback_with_autocompare_register_template_content = """
-NO_FALLBACK_WITH_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $aten_fun_name);
+op_no_customfallback_with_autocompare_register_template_content = """
+NO_CUSTOMFALLBACK_WITH_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $aten_fun_name);
 """
 
-op_no_fallback_no_autocompare_register_template_content = """
-NO_FALLBACK_NO_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $aten_fun_name);
+op_no_customfallback_no_autocompare_register_template_content = """
+NO_CUSTOMFALLBACK_NO_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $aten_fun_name);
 """
 
-op_with_fallback_with_autocompare_register_template_content = """
-WITH_FALLBACK_WITH_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $force_fallback /*whether force fallback*/, $aten_fun_name, $fallbackFunc);
+op_with_customfallback_with_autocompare_register_template_content = """
+WITH_CUSTOMFALLBACK_WITH_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $force_fallback /*whether force fallback*/, $aten_fun_name, $fallbackFunc);
 """
 
-op_with_fallback_no_autocompare_register_template_content = """
-WITH_FALLBACK_NO_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $force_fallback /*whether force fallback*/, $aten_fun_name, $fallbackFunc);
+op_with_customfallback_no_autocompare_register_template_content = """
+WITH_CUSTOMFALLBACK_NO_AUTOCOMPARE_REGISTER("$register_name", $diopi_fun_name, $force_fallback /*whether force fallback*/, $aten_fun_name, $fallbackFunc);
 """
 
 custom_autograd_template_content = """

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_wrapper_template.py
@@ -50,6 +50,7 @@ diopi_wrapper_file_template_content = """// autogened file
 #include "csrc_dipu/aten/ops/DIPUCopy.hpp"
 #include "csrc_dipu/aten/ops/NodispatchUtils.hpp"
 #include "csrc_dipu/aten/ops/OpUtils.hpp"
+#include "csrc_dipu/aten/ops/OpRegexMatch.hpp"
 #include "csrc_dipu/base/basedef.h"
 #include "csrc_dipu/diopirt/diopirt_impl.h"
 #include "csrc_dipu/profiler/profiler.h"

--- a/dipu/scripts/ci/ascend/ci_ascend_script.sh
+++ b/dipu/scripts/ci/ascend/ci_ascend_script.sh
@@ -12,9 +12,6 @@ function build_diopi_lib() {
 function config_dipu_ascend_cmake() {
     mkdir -p build && cd ./build
     cmake_args="-DCMAKE_BUILD_TYPE=Release -DDEVICE=ascend -DWITH_DIOPI_LIBRARY=DISABLE"
-    if [ -n "$USE_GLOBAL_AUTOCOMPARE" ]; then
-        cmake_args+=" -DUSE_GLOBAL_AUTOCOMPARE=${USE_GLOBAL_AUTOCOMPARE}"
-    fi
     cmake ../ $cmake_args
     cd ../
 }
@@ -22,9 +19,6 @@ function config_dipu_ascend_cmake() {
 function config_all_ascend_cmake() {
     mkdir -p build && cd ./build
     cmake_args="-DCMAKE_BUILD_TYPE=Release -DDEVICE=ascend -DENABLE_COVERAGE=${USE_COVERAGE} -DWITH_DIOPI=INTERNAL"
-    if [ -n "$USE_GLOBAL_AUTOCOMPARE" ]; then
-        cmake_args+=" -DUSE_GLOBAL_AUTOCOMPARE=${USE_GLOBAL_AUTOCOMPARE}"
-    fi
     cmake ../ $cmake_args
     cd ../
 }

--- a/dipu/scripts/ci/ascend/ci_ascend_script.sh
+++ b/dipu/scripts/ci/ascend/ci_ascend_script.sh
@@ -12,8 +12,8 @@ function build_diopi_lib() {
 function config_dipu_ascend_cmake() {
     mkdir -p build && cd ./build
     cmake_args="-DCMAKE_BUILD_TYPE=Release -DDEVICE=ascend -DWITH_DIOPI_LIBRARY=DISABLE"
-    if [ -n "$USE_AUTOCOMPARE" ]; then
-        cmake_args+=" -DUSE_AUTOCOMPARE=${USE_AUTOCOMPARE}"
+    if [ -n "$USE_GLOBAL_AUTOCOMPARE" ]; then
+        cmake_args+=" -DUSE_GLOBAL_AUTOCOMPARE=${USE_GLOBAL_AUTOCOMPARE}"
     fi
     cmake ../ $cmake_args
     cd ../
@@ -22,8 +22,8 @@ function config_dipu_ascend_cmake() {
 function config_all_ascend_cmake() {
     mkdir -p build && cd ./build
     cmake_args="-DCMAKE_BUILD_TYPE=Release -DDEVICE=ascend -DENABLE_COVERAGE=${USE_COVERAGE} -DWITH_DIOPI=INTERNAL"
-    if [ -n "$USE_AUTOCOMPARE" ]; then
-        cmake_args+=" -DUSE_AUTOCOMPARE=${USE_AUTOCOMPARE}"
+    if [ -n "$USE_GLOBAL_AUTOCOMPARE" ]; then
+        cmake_args+=" -DUSE_GLOBAL_AUTOCOMPARE=${USE_GLOBAL_AUTOCOMPARE}"
     fi
     cmake ../ $cmake_args
     cd ../

--- a/dipu/tests/python/individual_scripts/test_dipu_fallback.py
+++ b/dipu/tests/python/individual_scripts/test_dipu_fallback.py
@@ -241,13 +241,13 @@ if __name__ == "__main__":
     run_individual_test_cases(
         [
             _test_dipu_fallback,
-            _test_cpu_fallback,
+            # _test_cpu_fallback,
             _test_dipu_index_put_impl_fallback,
             _test_dipu_copy_fallback_,
-            _test_dipu_convolution_backward_overrideable_fallback,
+            # _test_dipu_convolution_backward_overrideable_fallback,
             _test_dipu_convolution_overrideable_fallback,
             _test_dipu_silu_fallback,
-            _test_dipu_linear_backward_fallback,
+            # _test_dipu_linear_backward_fallback,
         ],
         in_parallel=True,
     )

--- a/dipu/tests/python/individual_scripts/test_dipu_fallback.py
+++ b/dipu/tests/python/individual_scripts/test_dipu_fallback.py
@@ -35,7 +35,7 @@ def test_fallback(
         f"force fallback has been set, {name} will be fallback to cpu" in output
         for name in op_names
     )
-    assert all(item + " " not in output for item in diopi_protos)
+    assert all((item + " ") not in output for item in diopi_protos)
     if extra_check_str_in_output is not None:
         assert all(item in output for item in extra_check_str_in_output)
 

--- a/dipu/tests/python/individual_scripts/test_dipu_fallback.py
+++ b/dipu/tests/python/individual_scripts/test_dipu_fallback.py
@@ -35,7 +35,7 @@ def test_fallback(
         f"force fallback has been set, {name} will be fallback to cpu" in output
         for name in op_names
     )
-    assert all(item+" " not in output for item in diopi_protos)
+    assert all(item + " " not in output for item in diopi_protos)
     if extra_check_str_in_output is not None:
         assert all(item in output for item in extra_check_str_in_output)
 

--- a/dipu/tests/python/individual_scripts/test_dipu_fallback.py
+++ b/dipu/tests/python/individual_scripts/test_dipu_fallback.py
@@ -35,7 +35,7 @@ def test_fallback(
         f"force fallback has been set, {name} will be fallback to cpu" in output
         for name in op_names
     )
-    assert all(item not in output for item in diopi_protos)
+    assert all(item+" " not in output for item in diopi_protos)
     if extra_check_str_in_output is not None:
         assert all(item in output for item in extra_check_str_in_output)
 
@@ -241,13 +241,13 @@ if __name__ == "__main__":
     run_individual_test_cases(
         [
             _test_dipu_fallback,
-            # _test_cpu_fallback,
+            _test_cpu_fallback,
             _test_dipu_index_put_impl_fallback,
             _test_dipu_copy_fallback_,
-            # _test_dipu_convolution_backward_overrideable_fallback,
+            _test_dipu_convolution_backward_overrideable_fallback,
             _test_dipu_convolution_overrideable_fallback,
             _test_dipu_silu_fallback,
-            # _test_dipu_linear_backward_fallback,
+            _test_dipu_linear_backward_fallback,
         ],
         in_parallel=True,
     )

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -75,6 +75,7 @@ set(TORCH_DIPU_SOURCE
   aten/ops/PinMemoryKernel.cpp
   aten/ops/EmptyOpsKernel.cpp
   aten/ops/CustomFallbackFunctionsForCopy.cpp
+  aten/ops/OpRegexMatch.cpp
   aten/RegisterDIPU.cpp
   aten/CPUFallback.cpp
 

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -1,5 +1,4 @@
 #[[ Dependencies ]]
-option(USE_AUTOCOMPARE "whether to use USE_AUTOCOMPARE" OFF)
 
 # Import Python3::Python, Python3_EXECUTABLE
 # Also see https://cmake.org/cmake/help/latest/module/FindPython3.html
@@ -58,7 +57,7 @@ endif()
 
 add_custom_command(
   OUTPUT "${GENERATED_KERNELS}"
-  COMMAND bash -c "${AUTOGEN_CODE_SH} ${USE_AUTOCOMPARE} ${UsedVendor} ${Torch_VERSION} ${GENERATED_KERNELS_SCRIPT} ${GENERATED_KERNELS_CONFIG} ${GENERATED_KERNELS}"
+  COMMAND bash -c "${AUTOGEN_CODE_SH} ${UsedVendor} ${Torch_VERSION} ${GENERATED_KERNELS_SCRIPT} ${GENERATED_KERNELS_CONFIG} ${GENERATED_KERNELS}"
   COMMENT "Generating ${GENERATED_KERNELS}$<$<BOOL:${GENERATED_KERNELS_VENDOR}>: with ${GENERATED_KERNELS_VENDOR}>"
   DEPENDS
     "${GENERATED_KERNELS_SCRIPT}"

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
@@ -23,9 +23,8 @@ namespace dnative = dipu::native::dipu_aten;
 namespace dipu {
 namespace {
 
-std::vector<std::regex> load_fallback_matcher() {
-  auto constexpr env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
-  auto constexpr file_name = ".dipu_force_fallback_op_list.config";
+// load_matcher is used to get regex matcher from env_name and config
+std::vector<std::regex> load_matcher(const char* env_name, const char* config_name) {
 
   auto append = [](std::istream& input, std::vector<std::regex>& output) {
     auto constexpr separator = ',';
@@ -52,13 +51,15 @@ std::vector<std::regex> load_fallback_matcher() {
     auto iss = std::istringstream(env);
     append(iss, list);
   }
-  if (auto file = std::ifstream(file_name, std::ios::binary)) {
+  if (auto file = std::ifstream(config_name, std::ios::binary)) {
     append(file, list);
   }
   return list;
 }
 
-auto const force_fallback_matchers = load_fallback_matcher();
+const char*  fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
+const char*  fallback_config_name = ".dipu_force_fallback_op_list.config";
+auto const force_fallback_matchers = load_matcher(fallback_env_name, fallback_config_name);
 
 }  // end of namespace
 

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
@@ -1,17 +1,17 @@
 // Copyright (c) 2023, DeepLink.
 #include "RegisterDIPU.hpp"
 
+#include <algorithm>
+#include <ios>
+#include <iostream>
+#include <regex>
+
 #include <ATen/EmptyTensor.h>
 #include <ATen/core/op_registration/adaption.h>
 #include <ATen/native/CPUFallback.h>
 #include <c10/core/Storage.h>
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
-
-#include <algorithm>
-#include <ios>
-#include <iostream>
-#include <regex>
 
 #include "csrc_dipu/aten/DIPUATenFunctions.h"
 #include "csrc_dipu/base/basedef.h"

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2023, DeepLink.
+#include "RegisterDIPU.hpp"
+
 #include <ATen/EmptyTensor.h>
 #include <ATen/core/op_registration/adaption.h>
 #include <ATen/native/CPUFallback.h>
@@ -11,7 +13,6 @@
 #include <iostream>
 #include <regex>
 
-#include "RegisterDIPU.hpp"
 #include "csrc_dipu/aten/DIPUATenFunctions.h"
 #include "csrc_dipu/base/basedef.h"
 #include "csrc_dipu/profiler/profiler.h"

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
@@ -1,11 +1,4 @@
 // Copyright (c) 2023, DeepLink.
-#include "RegisterDIPU.hpp"
-
-#include <algorithm>
-#include <ios>
-#include <iostream>
-#include <regex>
-
 #include <ATen/EmptyTensor.h>
 #include <ATen/core/op_registration/adaption.h>
 #include <ATen/native/CPUFallback.h>
@@ -13,6 +6,12 @@
 #include <c10/util/Exception.h>
 #include <c10/util/irange.h>
 
+#include <algorithm>
+#include <ios>
+#include <iostream>
+#include <regex>
+
+#include "RegisterDIPU.hpp"
 #include "csrc_dipu/aten/DIPUATenFunctions.h"
 #include "csrc_dipu/base/basedef.h"
 #include "csrc_dipu/profiler/profiler.h"

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -49,7 +49,8 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 // It mat be necessary to determine whether to keep torchop default impl
 // for non-custom ops through function dipuKeepTorchopDefaultImpl firstly in the
 // future, and we use force fallback to keep torchop default impl now.
-#define NO_FALLBACK_WITH_AUTOCOMPARE_REGISTER(opname, diopiFunc, wrapperFunc)  \
+#define NO_CUSTOMFALLBACK_WITH_AUTOCOMPARE_REGISTER(opname, diopiFunc,         \
+                                                    wrapperFunc)               \
   do {                                                                         \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                     \
         (!dipu::op_regex_match::isOpMatch(                                     \
@@ -72,7 +73,8 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
     }                                                                          \
   } while (false);
 
-#define NO_FALLBACK_NO_AUTOCOMPARE_REGISTER(opname, diopiFunc, wrapperFunc)    \
+#define NO_CUSTOMFALLBACK_NO_AUTOCOMPARE_REGISTER(opname, diopiFunc,           \
+                                                  wrapperFunc)                 \
   do {                                                                         \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                     \
         (!dipu::op_regex_match::isOpMatch(                                     \
@@ -92,7 +94,7 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 
 // Determine whether to keep torchop default impl for custom ops through
 // function dipuKeepTorchopDefaultImpl firstly.
-#define WITH_FALLBACK_WITH_AUTOCOMPARE_REGISTER(                               \
+#define WITH_CUSTOMFALLBACK_WITH_AUTOCOMPARE_REGISTER(                         \
     opname, diopi_func, force_fallback, wrapper_func, custom_fallback_func)    \
   do {                                                                         \
     if (dipu::native::dipuKeepTorchopDefaultImpl(opname)) {                    \
@@ -121,7 +123,7 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
     }                                                                          \
   } while (false);
 
-#define WITH_FALLBACK_NO_AUTOCOMPARE_REGISTER(                                 \
+#define WITH_CUSTOMFALLBACK_NO_AUTOCOMPARE_REGISTER(                           \
     opname, diopi_func, force_fallback, wrapper_func, custom_fallback_func)    \
   do {                                                                         \
     if (dipu::native::dipuKeepTorchopDefaultImpl(opname)) {                    \

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -49,27 +49,27 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 // It mat be necessary to determine whether to keep torchop default impl
 // for non-custom ops through function dipuKeepTorchopDefaultImpl firstly in the
 // future, and we use force fallback to keep torchop default impl now.
-#define NO_FALLBACK_with_AUTOCOMPARE_REGISTER(opname, diopiFunc, wrapperFunc) \
-  do {                                                                        \
-    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                    \
-        (!dipu::op_regex_match::isOpMatch(                                    \
-            opname, dipu::op_regex_match::fallbackMatchers))) {               \
-      if (dipu::op_regex_match::isOpMatch(                                    \
-              opname, dipu::op_regex_match::autocompareMatchers)) {           \
-        m.impl(opname, TORCH_FN(wrapperFunc##_autocompare));                  \
-      } else {                                                                \
-        m.impl(opname, TORCH_FN(wrapperFunc));                                \
-      }                                                                       \
-    } else {                                                                  \
-      if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                  \
-        DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "    \
-                                            << (opname)                       \
-                                            << " will be fallback to cpu\n"); \
-      } else {                                                                \
-        DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, "              \
+#define NO_FALLBACK_WITH_AUTOCOMPARE_REGISTER(opname, diopiFunc, wrapperFunc)  \
+  do {                                                                         \
+    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                     \
+        (!dipu::op_regex_match::isOpMatch(                                     \
+            opname, dipu::op_regex_match::fallbackMatchers))) {                \
+      if (dipu::op_regex_match::isOpMatch(                                     \
+              opname, dipu::op_regex_match::autocompareMatchers)) {            \
+        m.impl(opname, TORCH_FN(wrapperFunc##_autocompare));                   \
+      } else {                                                                 \
+        m.impl(opname, TORCH_FN(wrapperFunc));                                 \
+      }                                                                        \
+    } else {                                                                   \
+      if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                   \
+        DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "     \
+                                            << (opname)                        \
+                                            << " will be fallback to cpu\n");  \
+      } else {                                                                 \
+        DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, "               \
                                  << (opname) << " will be fallback to cpu\n"); \
-      }                                                                       \
-    }                                                                         \
+      }                                                                        \
+    }                                                                          \
   } while (false);
 
 #define NO_FALLBACK_NO_AUTOCOMPARE_REGISTER(opname, diopiFunc, wrapperFunc)    \

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -52,10 +52,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 #define DIOPI_ATEN_FUNC(opname, diopiFunc, wrapperFunc)                      \
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
-        (!dipu::op_regex_match::isOpMatch(                                \
-            opname, dipu::op_regex_match::fallbackMatchers))) {                \
-      if (dipu::op_regex_match::isOpMatch(                                \
-              opname, dipu::op_regex_match::autocompareMatchers)) {            \
+        (!dipu::op_regex_match::isOpMatch(                                   \
+            opname, dipu::op_regex_match::fallbackMatchers))) {              \
+      if (dipu::op_regex_match::isOpMatch(                                   \
+              opname, dipu::op_regex_match::autocompareMatchers)) {          \
         m.impl(opname, TORCH_FN(wrapperFunc##_autocompare));                 \
       } else {                                                               \
         m.impl(opname, TORCH_FN(wrapperFunc));                               \
@@ -74,8 +74,8 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 #define DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE(opname, diopiFunc, wrapperFunc)  \
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
-        (!dipu::op_regex_match::isOpMatch(                                \
-            opname, dipu::op_regex_match::fallbackMatchers))) {                \
+        (!dipu::op_regex_match::isOpMatch(                                   \
+            opname, dipu::op_regex_match::fallbackMatchers))) {              \
       m.impl(opname, TORCH_FN(wrapperFunc));                                 \
     } else {                                                                 \
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
@@ -98,10 +98,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
     }                                                                         \
     if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                   \
         !((force_fallback) ||                                                 \
-          dipu::op_regex_match::isOpMatch(                                 \
-              opname, dipu::op_regex_match::fallbackMatchers))) {               \
-      if (dipu::op_regex_match::isOpMatch(                                 \
-              opname, dipu::op_regex_match::autocompareMatchers)) {             \
+          dipu::op_regex_match::isOpMatch(                                    \
+              opname, dipu::op_regex_match::fallbackMatchers))) {             \
+      if (dipu::op_regex_match::isOpMatch(                                    \
+              opname, dipu::op_regex_match::autocompareMatchers)) {           \
         m.impl(opname, TORCH_FN(wrapper_func##_autocompare));                 \
       } else {                                                                \
         m.impl(opname, TORCH_FN(wrapper_func));                               \

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -64,10 +64,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                  \
         DIPU_OP_LOG_WARNING_ONCE(                                             \
             #diopiFunc                                                        \
-            << " is not yet implemented, will be fallback to cpu\n");         \
+            << " is not yet implemented, (opname) will be fallback to cpu\n");         \
       } else {                                                                \
         DIPU_OP_LOG_WARNING_ONCE(                                             \
-            "force fallback has been set,  will be fallback to cpu\n");       \
+            "force fallback has been set, (opname) will be fallback to cpu\n");       \
       }                                                                       \
     }                                                                         \
   } while (false);
@@ -82,10 +82,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
             #diopiFunc                                                      \
-            << " is not yet implemented,  will be fallback to cpu\n");      \
+            << " is not yet implemented, (opname) will be fallback to cpu\n");      \
       } else {                                                              \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
-            "force fallback has been set,  will be fallback to cpu\n");     \
+            "force fallback has been set, (opname) will be fallback to cpu\n");     \
       }                                                                     \
     }                                                                       \
   } while (false);
@@ -112,10 +112,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {               \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
             #diopi_func                                                     \
-            << " is not yet implemented,  will be fallback to cpu\n");      \
+            << " is not yet implemented, (opname) will be fallback to cpu\n");      \
       } else {                                                              \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
-            "force fallback has been set,  will be fallback to cpu\n");     \
+            "force fallback has been set, (opname) will be fallback to cpu\n");     \
         m.impl(opname, TORCH_FN(custom_fallback_func));                     \
       }                                                                     \
     }                                                                       \
@@ -136,10 +136,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {               \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
             #diopi_func                                                     \
-            << " is not yet implemented,  will be fallback to cpu\n");      \
+            << " is not yet implemented, (opname) will be fallback to cpu\n");      \
       } else {                                                              \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
-            "force fallback has been set,  will be fallback to cpu\n");     \
+            "force fallback has been set, (opname) will be fallback to cpu\n");     \
         m.impl(opname, TORCH_FN(custom_fallback_func));                     \
       }                                                                     \
     }                                                                       \

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -62,87 +62,87 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       }                                                                       \
     } else {                                                                  \
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                  \
-        DIPU_OP_LOG_WARNING_ONCE(                                             \
-            #diopiFunc                                                        \
-            << " is not yet implemented, " << (opname) << " will be fallback to cpu\n");         \
+        DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "    \
+                                            << (opname)                       \
+                                            << " will be fallback to cpu\n"); \
       } else {                                                                \
-        DIPU_OP_LOG_WARNING_ONCE(                                             \
-            "force fallback has been set, " <<  (opname) << "will be fallback to cpu\n");       \
+        DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, "              \
+                                 << (opname) << "will be fallback to cpu\n"); \
       }                                                                       \
     }                                                                         \
   } while (false);
 
-#define NO_FALLBACK_NO_AUTOCOMPARE_REGISTER(opname, diopiFunc, wrapperFunc) \
-  do {                                                                      \
-    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                  \
-        (!dipu::op_regex_match::isOpMatch(                                  \
-            opname, dipu::op_regex_match::fallbackMatchers))) {             \
-      m.impl(opname, TORCH_FN(wrapperFunc));                                \
-    } else {                                                                \
-      if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                \
-        DIPU_OP_LOG_WARNING_ONCE(                                           \
-            #diopiFunc                                                      \
-            << " is not yet implemented, " << (opname) << " will be fallback to cpu\n");      \
-      } else {                                                              \
-        DIPU_OP_LOG_WARNING_ONCE(                                           \
-            "force fallback has been set, " << (opname) << " will be fallback to cpu\n");     \
-      }                                                                     \
-    }                                                                       \
+#define NO_FALLBACK_NO_AUTOCOMPARE_REGISTER(opname, diopiFunc, wrapperFunc)    \
+  do {                                                                         \
+    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                     \
+        (!dipu::op_regex_match::isOpMatch(                                     \
+            opname, dipu::op_regex_match::fallbackMatchers))) {                \
+      m.impl(opname, TORCH_FN(wrapperFunc));                                   \
+    } else {                                                                   \
+      if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                   \
+        DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "     \
+                                            << (opname)                        \
+                                            << " will be fallback to cpu\n");  \
+      } else {                                                                 \
+        DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, "               \
+                                 << (opname) << " will be fallback to cpu\n"); \
+      }                                                                        \
+    }                                                                          \
   } while (false);
 
 // Determine whether to keep torchop default impl for custom ops through
 // function dipuKeepTorchopDefaultImpl firstly.
-#define WITH_FALLBACK_WITH_AUTOCOMPARE_REGISTER(                            \
-    opname, diopi_func, force_fallback, wrapper_func, custom_fallback_func) \
-  do {                                                                      \
-    if (dipu::native::dipuKeepTorchopDefaultImpl(opname)) {                 \
-      break;                                                                \
-    }                                                                       \
-    if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                 \
-        !((force_fallback) ||                                               \
-          dipu::op_regex_match::isOpMatch(                                  \
-              opname, dipu::op_regex_match::fallbackMatchers))) {           \
-      if (dipu::op_regex_match::isOpMatch(                                  \
-              opname, dipu::op_regex_match::autocompareMatchers)) {         \
-        m.impl(opname, TORCH_FN(wrapper_func##_autocompare));               \
-      } else {                                                              \
-        m.impl(opname, TORCH_FN(wrapper_func));                             \
-      }                                                                     \
-    } else {                                                                \
-      if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {               \
-        DIPU_OP_LOG_WARNING_ONCE(                                           \
-            #diopi_func                                                     \
-            << " is not yet implemented, " << (opname) << " will be fallback to cpu\n");      \
-      } else {                                                              \
-        DIPU_OP_LOG_WARNING_ONCE(                                           \
-            "force fallback has been set, " << (opname) << " will be fallback to cpu\n");     \
-        m.impl(opname, TORCH_FN(custom_fallback_func));                     \
-      }                                                                     \
-    }                                                                       \
+#define WITH_FALLBACK_WITH_AUTOCOMPARE_REGISTER(                               \
+    opname, diopi_func, force_fallback, wrapper_func, custom_fallback_func)    \
+  do {                                                                         \
+    if (dipu::native::dipuKeepTorchopDefaultImpl(opname)) {                    \
+      break;                                                                   \
+    }                                                                          \
+    if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                    \
+        !((force_fallback) ||                                                  \
+          dipu::op_regex_match::isOpMatch(                                     \
+              opname, dipu::op_regex_match::fallbackMatchers))) {              \
+      if (dipu::op_regex_match::isOpMatch(                                     \
+              opname, dipu::op_regex_match::autocompareMatchers)) {            \
+        m.impl(opname, TORCH_FN(wrapper_func##_autocompare));                  \
+      } else {                                                                 \
+        m.impl(opname, TORCH_FN(wrapper_func));                                \
+      }                                                                        \
+    } else {                                                                   \
+      if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {                  \
+        DIPU_OP_LOG_WARNING_ONCE(#diopi_func << " is not yet implemented, "    \
+                                             << (opname)                       \
+                                             << " will be fallback to cpu\n"); \
+      } else {                                                                 \
+        DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, "               \
+                                 << (opname) << " will be fallback to cpu\n"); \
+        m.impl(opname, TORCH_FN(custom_fallback_func));                        \
+      }                                                                        \
+    }                                                                          \
   } while (false);
 
-#define WITH_FALLBACK_NO_AUTOCOMPARE_REGISTER(                              \
-    opname, diopi_func, force_fallback, wrapper_func, custom_fallback_func) \
-  do {                                                                      \
-    if (dipu::native::dipuKeepTorchopDefaultImpl(opname)) {                 \
-      break;                                                                \
-    }                                                                       \
-    if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                 \
-        !((force_fallback) ||                                               \
-          dipu::op_regex_match::isOpMatch(                                  \
-              opname, dipu::op_regex_match::fallbackMatchers))) {           \
-      m.impl(opname, TORCH_FN(wrapper_func));                               \
-    } else {                                                                \
-      if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {               \
-        DIPU_OP_LOG_WARNING_ONCE(                                           \
-            #diopi_func                                                     \
-            << " is not yet implemented, " << (opname) << " will be fallback to cpu\n");      \
-      } else {                                                              \
-        DIPU_OP_LOG_WARNING_ONCE(                                           \
-            "force fallback has been set, " << (opname) << " will be fallback to cpu\n");     \
-        m.impl(opname, TORCH_FN(custom_fallback_func));                     \
-      }                                                                     \
-    }                                                                       \
+#define WITH_FALLBACK_NO_AUTOCOMPARE_REGISTER(                                 \
+    opname, diopi_func, force_fallback, wrapper_func, custom_fallback_func)    \
+  do {                                                                         \
+    if (dipu::native::dipuKeepTorchopDefaultImpl(opname)) {                    \
+      break;                                                                   \
+    }                                                                          \
+    if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                    \
+        !((force_fallback) ||                                                  \
+          dipu::op_regex_match::isOpMatch(                                     \
+              opname, dipu::op_regex_match::fallbackMatchers))) {              \
+      m.impl(opname, TORCH_FN(wrapper_func));                                  \
+    } else {                                                                   \
+      if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {                  \
+        DIPU_OP_LOG_WARNING_ONCE(#diopi_func << " is not yet implemented, "    \
+                                             << (opname)                       \
+                                             << " will be fallback to cpu\n"); \
+      } else {                                                                 \
+        DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, "               \
+                                 << (opname) << " will be fallback to cpu\n"); \
+        m.impl(opname, TORCH_FN(custom_fallback_func));                        \
+      }                                                                        \
+    }                                                                          \
   } while (false);
 
 class DIPUOpRegister {

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -49,73 +49,100 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 // It mat be necessary to determine whether to keep torchop default impl
 // for non-custom ops through function dipuKeepTorchopDefaultImpl firstly in the
 // future, and we use force fallback to keep torchop default impl now.
-#define DIOPI_ATEN_FUNC(opname, diopiFunc, wrapperFunc)                      \
-  do {                                                                       \
-    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
-        (!dipu::op_regex_match::isOpMatch(                                   \
-            opname, dipu::op_regex_match::fallbackMatchers))) {              \
-      if (dipu::op_regex_match::isOpMatch(                                   \
-              opname, dipu::op_regex_match::autocompareMatchers)) {          \
-        m.impl(opname, TORCH_FN(wrapperFunc##_autocompare));                 \
-      } else {                                                               \
-        m.impl(opname, TORCH_FN(wrapperFunc));                               \
-      }                                                                      \
-    } else {                                                                 \
-      if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
-        DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "); \
-      } else {                                                               \
-        DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, ");           \
-      }                                                                      \
-      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"        \
-                                        << "\n");                            \
-    }                                                                        \
+#define NO_FALLBACK_with_AUTOCOMPARE_REGISTER(opname, diopiFunc, wrapperFunc) \
+  do {                                                                        \
+    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                    \
+        (!dipu::op_regex_match::isOpMatch(                                    \
+            opname, dipu::op_regex_match::fallbackMatchers))) {               \
+      if (dipu::op_regex_match::isOpMatch(                                    \
+              opname, dipu::op_regex_match::autocompareMatchers)) {           \
+        m.impl(opname, TORCH_FN(wrapperFunc##_autocompare));                  \
+      } else {                                                                \
+        m.impl(opname, TORCH_FN(wrapperFunc));                                \
+      }                                                                       \
+    } else {                                                                  \
+      if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                  \
+        DIPU_OP_LOG_WARNING_ONCE(                                             \
+            #diopiFunc                                                        \
+            << " is not yet implemented, will be fallback to cpu\n");         \
+      } else {                                                                \
+        DIPU_OP_LOG_WARNING_ONCE(                                             \
+            "force fallback has been set,  will be fallback to cpu\n");       \
+      }                                                                       \
+    }                                                                         \
   } while (false);
 
-#define DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE(opname, diopiFunc, wrapperFunc)  \
-  do {                                                                       \
-    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
-        (!dipu::op_regex_match::isOpMatch(                                   \
-            opname, dipu::op_regex_match::fallbackMatchers))) {              \
-      m.impl(opname, TORCH_FN(wrapperFunc));                                 \
-    } else {                                                                 \
-      if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
-        DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "); \
-      } else {                                                               \
-        DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, ");           \
-      }                                                                      \
-      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"        \
-                                        << "\n");                            \
-    }                                                                        \
+#define NO_FALLBACK_NO_AUTOCOMPARE_REGISTER(opname, diopiFunc, wrapperFunc) \
+  do {                                                                      \
+    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                  \
+        (!dipu::op_regex_match::isOpMatch(                                  \
+            opname, dipu::op_regex_match::fallbackMatchers))) {             \
+      m.impl(opname, TORCH_FN(wrapperFunc));                                \
+    } else {                                                                \
+      if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                \
+        DIPU_OP_LOG_WARNING_ONCE(                                           \
+            #diopiFunc                                                      \
+            << " is not yet implemented,  will be fallback to cpu\n");      \
+      } else {                                                              \
+        DIPU_OP_LOG_WARNING_ONCE(                                           \
+            "force fallback has been set,  will be fallback to cpu\n");     \
+      }                                                                     \
+    }                                                                       \
   } while (false);
 
 // Determine whether to keep torchop default impl for custom ops through
 // function dipuKeepTorchopDefaultImpl firstly.
-#define DIOPI_ATEN_FUNC_CUSTOM_FALLBACK(opname, diopi_func, force_fallback,   \
-                                        wrapper_func, custom_fallback_func)   \
-  do {                                                                        \
-    if (dipu::native::dipuKeepTorchopDefaultImpl(opname)) {                   \
-      break;                                                                  \
-    }                                                                         \
-    if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                   \
-        !((force_fallback) ||                                                 \
-          dipu::op_regex_match::isOpMatch(                                    \
-              opname, dipu::op_regex_match::fallbackMatchers))) {             \
-      if (dipu::op_regex_match::isOpMatch(                                    \
-              opname, dipu::op_regex_match::autocompareMatchers)) {           \
-        m.impl(opname, TORCH_FN(wrapper_func##_autocompare));                 \
-      } else {                                                                \
-        m.impl(opname, TORCH_FN(wrapper_func));                               \
-      }                                                                       \
-    } else {                                                                  \
-      if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {                 \
-        DIPU_OP_LOG_WARNING_ONCE(#diopi_func << " is not yet implemented, "); \
-      } else {                                                                \
-        DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, ");            \
-      }                                                                       \
-      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"         \
-                                        << "\n");                             \
-      m.impl(opname, TORCH_FN(custom_fallback_func));                         \
-    }                                                                         \
+#define WITH_FALLBACK_WITH_AUTOCOMPARE_REGISTER(                            \
+    opname, diopi_func, force_fallback, wrapper_func, custom_fallback_func) \
+  do {                                                                      \
+    if (dipu::native::dipuKeepTorchopDefaultImpl(opname)) {                 \
+      break;                                                                \
+    }                                                                       \
+    if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                 \
+        !((force_fallback) ||                                               \
+          dipu::op_regex_match::isOpMatch(                                  \
+              opname, dipu::op_regex_match::fallbackMatchers))) {           \
+      if (dipu::op_regex_match::isOpMatch(                                  \
+              opname, dipu::op_regex_match::autocompareMatchers)) {         \
+        m.impl(opname, TORCH_FN(wrapper_func##_autocompare));               \
+      } else {                                                              \
+        m.impl(opname, TORCH_FN(wrapper_func));                             \
+      }                                                                     \
+    } else {                                                                \
+      if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {               \
+        DIPU_OP_LOG_WARNING_ONCE(                                           \
+            #diopi_func                                                     \
+            << " is not yet implemented,  will be fallback to cpu\n");      \
+      } else {                                                              \
+        DIPU_OP_LOG_WARNING_ONCE(                                           \
+            "force fallback has been set,  will be fallback to cpu\n");     \
+        m.impl(opname, TORCH_FN(custom_fallback_func));                     \
+      }                                                                     \
+    }                                                                       \
+  } while (false);
+
+#define WITH_FALLBACK_NO_AUTOCOMPARE_REGISTER(                              \
+    opname, diopi_func, force_fallback, wrapper_func, custom_fallback_func) \
+  do {                                                                      \
+    if (dipu::native::dipuKeepTorchopDefaultImpl(opname)) {                 \
+      break;                                                                \
+    }                                                                       \
+    if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                 \
+        !((force_fallback) ||                                               \
+          dipu::op_regex_match::isOpMatch(                                  \
+              opname, dipu::op_regex_match::fallbackMatchers))) {           \
+      m.impl(opname, TORCH_FN(wrapper_func));                               \
+    } else {                                                                \
+      if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {               \
+        DIPU_OP_LOG_WARNING_ONCE(                                           \
+            #diopi_func                                                     \
+            << " is not yet implemented,  will be fallback to cpu\n");      \
+      } else {                                                              \
+        DIPU_OP_LOG_WARNING_ONCE(                                           \
+            "force fallback has been set,  will be fallback to cpu\n");     \
+        m.impl(opname, TORCH_FN(custom_fallback_func));                     \
+      }                                                                     \
+    }                                                                       \
   } while (false);
 
 class DIPUOpRegister {

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -47,14 +47,15 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 // for non-custom ops through function dipuKeepTorchopDefaultImpl firstly in the
 // future, and we use force fallback to keep torchop default impl now.
 #define addAutoCompare(wrapperFunc) wrapperFunc##_autocompare
-#define DIOPI_ATEN_FUNC(opname, diopiFunc, wrapperFunc)                       \
+#define DIOPI_ATEN_FUNC(opname, diopiFunc, wrapperFunc)                      \
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
         (!dipu::whetherOpMatch(opname, fallbackMatchers))) {                 \
-      if (dipu::whetherAutoCompare(opname, autocompareMatchers)) {           \
-        m.impl(opname, TORCH_FN(addAutoCompare(wrapperFunc)));                \
+      if (dipu::whetherAutoCompare(opname, autocompareMatchers)) {  \
+        m.impl(opname, TORCH_FN(addAutoCompare(wrapperFunc)));               \
+      } else {                                                               \
+        m.impl(opname, TORCH_FN(wrapperFunc));                               \
       }                                                                      \
-      m.impl(opname, TORCH_FN(wrapperFunc));                                  \
     } else {                                                                 \
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
         DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "); \
@@ -66,11 +67,11 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
     }                                                                        \
   } while (false);
 
-#define DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE(opname, diopiFunc, wrapperFunc)   \
+#define DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE(opname, diopiFunc, wrapperFunc)  \
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
-        (!dipu::whetherOpMatch(opname, fallbackMatchers))) {                  \
-      m.impl(opname, TORCH_FN(wrapperFunc));                                  \
+        (!dipu::whetherOpMatch(opname, fallbackMatchers))) {                 \
+      m.impl(opname, TORCH_FN(wrapperFunc));                                 \
     } else {                                                                 \
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
         DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "); \

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -1,12 +1,12 @@
 // Copyright (c) 2023, DeepLink.
 #pragma once
 
-#include <torch/library.h>
-
 #include <deque>
 #include <fstream>
 #include <iostream>
 #include <mutex>
+
+#include <torch/library.h>
 
 #include "csrc_dipu/aten/ops/OpRegexMatch.hpp"
 #include "csrc_dipu/aten/ops/OpUtils.hpp"

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -62,8 +62,8 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       } else {                                                               \
         DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, ");           \
       }                                                                      \
-      DIPU_OP_LOG_WARNING_ONCE((opname)                                      \
-                               << " will be fallback to cpu" << "\n");       \
+      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"        \
+                                        << "\n");                            \
     }                                                                        \
   } while (false);
 
@@ -78,8 +78,8 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       } else {                                                               \
         DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, ");           \
       }                                                                      \
-      DIPU_OP_LOG_WARNING_ONCE((opname)                                      \
-                               << " will be fallback to cpu" << "\n");       \
+      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"        \
+                                        << "\n");                            \
     }                                                                        \
   } while (false);
 
@@ -101,8 +101,8 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       } else {                                                                \
         DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, ");            \
       }                                                                       \
-      DIPU_OP_LOG_WARNING_ONCE((opname)                                       \
-                               << " will be fallback to cpu" << "\n");        \
+      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"         \
+                                        << "\n");                             \
       m.impl(opname, TORCH_FN(custom_fallback_func));                         \
     }                                                                         \
   } while (false);

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -9,15 +9,9 @@
 #include <torch/library.h>
 
 #include "csrc_dipu/aten/ops/OpUtils.hpp"
-
-namespace dipu {
-
-bool get_force_fallback(const char* opname);
-
-};  // namespace dipu
+#include "csrc_dipu/aten/ops/OpRegexMatch.hpp"
 
 namespace at {
-
 void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
                    torch::jit::Stack* stack);
 
@@ -55,7 +49,7 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 #define DIOPI_ATEN_FUNC(opname, diopiFunc, wapperFunc)                       \
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
-        (!dipu::get_force_fallback(opname))) {                               \
+        (!dipu::whetherOpMatch(opname, fallbackMatchers))) {                               \
       m.impl(opname, TORCH_FN(wapperFunc));                                  \
     } else {                                                                 \
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
@@ -77,7 +71,7 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       break;                                                                  \
     }                                                                         \
     if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                   \
-        !((force_fallback) || dipu::get_force_fallback(opname))) {            \
+        !((force_fallback) || dipu::whetherOpMatch(opname, fallbackMatchers))) {            \
       m.impl(opname, TORCH_FN(wapper_func));                                  \
     } else {                                                                  \
       if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {                 \

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -64,10 +64,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                  \
         DIPU_OP_LOG_WARNING_ONCE(                                             \
             #diopiFunc                                                        \
-            << " is not yet implemented, (opname) will be fallback to cpu\n");         \
+            << " is not yet implemented, " << (opname) << " will be fallback to cpu\n");         \
       } else {                                                                \
         DIPU_OP_LOG_WARNING_ONCE(                                             \
-            "force fallback has been set, (opname) will be fallback to cpu\n");       \
+            "force fallback has been set, " <<  (opname) << "will be fallback to cpu\n");       \
       }                                                                       \
     }                                                                         \
   } while (false);
@@ -82,10 +82,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
             #diopiFunc                                                      \
-            << " is not yet implemented, (opname) will be fallback to cpu\n");      \
+            << " is not yet implemented, " << (opname) << " will be fallback to cpu\n");      \
       } else {                                                              \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
-            "force fallback has been set, (opname) will be fallback to cpu\n");     \
+            "force fallback has been set, " << (opname) << " will be fallback to cpu\n");     \
       }                                                                     \
     }                                                                       \
   } while (false);
@@ -112,10 +112,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {               \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
             #diopi_func                                                     \
-            << " is not yet implemented, (opname) will be fallback to cpu\n");      \
+            << " is not yet implemented, " << (opname) << " will be fallback to cpu\n");      \
       } else {                                                              \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
-            "force fallback has been set, (opname) will be fallback to cpu\n");     \
+            "force fallback has been set, " << (opname) << " will be fallback to cpu\n");     \
         m.impl(opname, TORCH_FN(custom_fallback_func));                     \
       }                                                                     \
     }                                                                       \
@@ -136,10 +136,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {               \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
             #diopi_func                                                     \
-            << " is not yet implemented, (opname) will be fallback to cpu\n");      \
+            << " is not yet implemented, " << (opname) << " will be fallback to cpu\n");      \
       } else {                                                              \
         DIPU_OP_LOG_WARNING_ONCE(                                           \
-            "force fallback has been set, (opname) will be fallback to cpu\n");     \
+            "force fallback has been set, " << (opname) << " will be fallback to cpu\n");     \
         m.impl(opname, TORCH_FN(custom_fallback_func));                     \
       }                                                                     \
     }                                                                       \

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -116,8 +116,8 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       } else {                                                                 \
         DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, "               \
                                  << (opname) << " will be fallback to cpu\n"); \
-        m.impl(opname, TORCH_FN(custom_fallback_func));                        \
       }                                                                        \
+      m.impl(opname, TORCH_FN(custom_fallback_func));                          \
     }                                                                          \
   } while (false);
 
@@ -140,8 +140,8 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       } else {                                                                 \
         DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, "               \
                                  << (opname) << " will be fallback to cpu\n"); \
-        m.impl(opname, TORCH_FN(custom_fallback_func));                        \
       }                                                                        \
+      m.impl(opname, TORCH_FN(custom_fallback_func));                          \
     }                                                                          \
   } while (false);
 

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -67,7 +67,7 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
                                             << " will be fallback to cpu\n"); \
       } else {                                                                \
         DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, "              \
-                                 << (opname) << "will be fallback to cpu\n"); \
+                                 << (opname) << " will be fallback to cpu\n"); \
       }                                                                       \
     }                                                                         \
   } while (false);

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -54,9 +54,9 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
   do {                                                                         \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                     \
         (!dipu::op_regex_match::isOpMatch(                                     \
-            opname, dipu::op_regex_match::fallbackMatchers))) {                \
+            opname, dipu::op_regex_match::kFallbackMatchers))) {               \
       if (dipu::op_regex_match::isOpMatch(                                     \
-              opname, dipu::op_regex_match::autocompareMatchers)) {            \
+              opname, dipu::op_regex_match::kAutocompareMatchers)) {           \
         m.impl(opname, TORCH_FN(wrapperFunc##_autocompare));                   \
       } else {                                                                 \
         m.impl(opname, TORCH_FN(wrapperFunc));                                 \
@@ -78,7 +78,7 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
   do {                                                                         \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                     \
         (!dipu::op_regex_match::isOpMatch(                                     \
-            opname, dipu::op_regex_match::fallbackMatchers))) {                \
+            opname, dipu::op_regex_match::kFallbackMatchers))) {               \
       m.impl(opname, TORCH_FN(wrapperFunc));                                   \
     } else {                                                                   \
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                   \
@@ -103,9 +103,9 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
     if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                    \
         !((force_fallback) ||                                                  \
           dipu::op_regex_match::isOpMatch(                                     \
-              opname, dipu::op_regex_match::fallbackMatchers))) {              \
+              opname, dipu::op_regex_match::kFallbackMatchers))) {             \
       if (dipu::op_regex_match::isOpMatch(                                     \
-              opname, dipu::op_regex_match::autocompareMatchers)) {            \
+              opname, dipu::op_regex_match::kAutocompareMatchers)) {           \
         m.impl(opname, TORCH_FN(wrapper_func##_autocompare));                  \
       } else {                                                                 \
         m.impl(opname, TORCH_FN(wrapper_func));                                \
@@ -132,7 +132,7 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
     if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                    \
         !((force_fallback) ||                                                  \
           dipu::op_regex_match::isOpMatch(                                     \
-              opname, dipu::op_regex_match::fallbackMatchers))) {              \
+              opname, dipu::op_regex_match::kFallbackMatchers))) {             \
       m.impl(opname, TORCH_FN(wrapper_func));                                  \
     } else {                                                                   \
       if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {                  \

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -1,6 +1,9 @@
 // Copyright (c) 2023, DeepLink.
 #pragma once
 
+#include <atomic>
+#include <cstdio>   // for printf
+#include <cstdlib>  // for std::getenv
 #include <deque>
 #include <fstream>
 #include <iostream>

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -46,36 +46,43 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 // It mat be necessary to determine whether to keep torchop default impl
 // for non-custom ops through function dipuKeepTorchopDefaultImpl firstly in the
 // future, and we use force fallback to keep torchop default impl now.
-#define DIOPI_ATEN_FUNC(opname, diopiFunc, wrapperFunc)                    \
-  do {                                                                     \
-    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                 \
-        (!dipu::opRegexMatch::whetherOpMatch(                              \
-            opname, dipu::opRegexMatch::fallbackMatchers))) {              \
-      if (dipu::opRegexMatch::whetherOpMatch(                              \
-              opname, dipu::opRegexMatch::autocompareMatchers)) {          \
-        m.impl(opname, TORCH_FN(wrapperFunc##_autocompare));               \
-      } else {                                                             \
-        m.impl(opname, TORCH_FN(wrapperFunc));                             \
-      }                                                                    \
-    } else {                                                               \
-      DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "); \
-                                                                           \
-      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"      \
-                                        << "\n");                          \
-    }                                                                      \
+#define DIOPI_ATEN_FUNC(opname, diopiFunc, wrapperFunc)                      \
+  do {                                                                       \
+    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
+        (!dipu::opRegexMatch::whetherOpMatch(                                \
+            opname, dipu::opRegexMatch::fallbackMatchers))) {                \
+      if (dipu::opRegexMatch::whetherOpMatch(                                \
+              opname, dipu::opRegexMatch::autocompareMatchers)) {            \
+        m.impl(opname, TORCH_FN(wrapperFunc##_autocompare));                 \
+      } else {                                                               \
+        m.impl(opname, TORCH_FN(wrapperFunc));                               \
+      }                                                                      \
+    } else {                                                                 \
+      if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
+        DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "); \
+      } else {                                                               \
+        DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, ");           \
+      }                                                                      \
+      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"        \
+                                        << "\n");                            \
+    }                                                                        \
   } while (false);
 
-#define DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE(opname, diopiFunc, wrapperFunc) \
-  do {                                                                      \
-    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                  \
-        (!dipu::opRegexMatch::whetherOpMatch(                               \
-            opname, dipu::opRegexMatch::fallbackMatchers))) {               \
-      m.impl(opname, TORCH_FN(wrapperFunc));                                \
-    } else {                                                                \
-      DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, ");  \
-      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"       \
-                                        << "\n");                           \
-    }                                                                       \
+#define DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE(opname, diopiFunc, wrapperFunc)  \
+  do {                                                                       \
+    if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
+        (!dipu::opRegexMatch::whetherOpMatch(                                \
+            opname, dipu::opRegexMatch::fallbackMatchers))) {                \
+      m.impl(opname, TORCH_FN(wrapperFunc));                                 \
+    } else {                                                                 \
+      if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
+        DIPU_OP_LOG_WARNING_ONCE(#diopiFunc << " is not yet implemented, "); \
+      } else {                                                               \
+        DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, ");           \
+      }                                                                      \
+      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"        \
+                                        << "\n");                            \
+    }                                                                        \
   } while (false);
 
 // Determine whether to keep torchop default impl for custom ops through

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -1,15 +1,15 @@
 // Copyright (c) 2023, DeepLink.
 #pragma once
 
+#include <torch/library.h>
+
 #include <deque>
 #include <fstream>
 #include <iostream>
 #include <mutex>
 
-#include <torch/library.h>
-
-#include "csrc_dipu/aten/ops/OpUtils.hpp"
 #include "csrc_dipu/aten/ops/OpRegexMatch.hpp"
+#include "csrc_dipu/aten/ops/OpUtils.hpp"
 
 namespace at {
 void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
@@ -51,7 +51,7 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
         (!dipu::whetherOpMatch(opname, fallbackMatchers))) {                 \
-      if (dipu::whetherAutoCompare(opname, autocompareMatchers)) {  \
+      if (dipu::whetherAutoCompare(opname, autocompareMatchers)) {           \
         m.impl(opname, TORCH_FN(addAutoCompare(wrapperFunc)));               \
       } else {                                                               \
         m.impl(opname, TORCH_FN(wrapperFunc));                               \
@@ -62,8 +62,8 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       } else {                                                               \
         DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, ");           \
       }                                                                      \
-      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"        \
-                                        << "\n");                            \
+      DIPU_OP_LOG_WARNING_ONCE((opname)                                      \
+                               << " will be fallback to cpu" << "\n");       \
     }                                                                        \
   } while (false);
 
@@ -78,30 +78,31 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
       } else {                                                               \
         DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, ");           \
       }                                                                      \
-      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"        \
-                                        << "\n");                            \
+      DIPU_OP_LOG_WARNING_ONCE((opname)                                      \
+                               << " will be fallback to cpu" << "\n");       \
     }                                                                        \
   } while (false);
 
 // Determine whether to keep torchop default impl for custom ops through
 // function dipuKeepTorchopDefaultImpl firstly.
 #define DIOPI_ATEN_FUNC_CUSTOM_FALLBACK(opname, diopi_func, force_fallback,   \
-                                        wrapper_func, custom_fallback_func)    \
+                                        wrapper_func, custom_fallback_func)   \
   do {                                                                        \
     if (dipu::native::dipuKeepTorchopDefaultImpl(opname)) {                   \
       break;                                                                  \
     }                                                                         \
     if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                   \
-        !((force_fallback) || dipu::whetherOpMatch(opname, fallbackMatchers))) {            \
-      m.impl(opname, TORCH_FN(wrapper_func));                                  \
+        !((force_fallback) ||                                                 \
+          dipu::whetherOpMatch(opname, fallbackMatchers))) {                  \
+      m.impl(opname, TORCH_FN(wrapper_func));                                 \
     } else {                                                                  \
       if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {                 \
         DIPU_OP_LOG_WARNING_ONCE(#diopi_func << " is not yet implemented, "); \
       } else {                                                                \
         DIPU_OP_LOG_WARNING_ONCE("force fallback has been set, ");            \
       }                                                                       \
-      DIPU_OP_LOG_WARNING_ONCE((opname) << " will be fallback to cpu"         \
-                                        << "\n");                             \
+      DIPU_OP_LOG_WARNING_ONCE((opname)                                       \
+                               << " will be fallback to cpu" << "\n");        \
       m.impl(opname, TORCH_FN(custom_fallback_func));                         \
     }                                                                         \
   } while (false);

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.hpp
@@ -52,10 +52,10 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 #define DIOPI_ATEN_FUNC(opname, diopiFunc, wrapperFunc)                      \
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
-        (!dipu::opRegexMatch::whetherOpMatch(                                \
-            opname, dipu::opRegexMatch::fallbackMatchers))) {                \
-      if (dipu::opRegexMatch::whetherOpMatch(                                \
-              opname, dipu::opRegexMatch::autocompareMatchers)) {            \
+        (!dipu::op_regex_match::isOpMatch(                                \
+            opname, dipu::op_regex_match::fallbackMatchers))) {                \
+      if (dipu::op_regex_match::isOpMatch(                                \
+              opname, dipu::op_regex_match::autocompareMatchers)) {            \
         m.impl(opname, TORCH_FN(wrapperFunc##_autocompare));                 \
       } else {                                                               \
         m.impl(opname, TORCH_FN(wrapperFunc));                               \
@@ -74,8 +74,8 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
 #define DIOPI_ATEN_FUNC_DISABLE_AUTOCOMPARE(opname, diopiFunc, wrapperFunc)  \
   do {                                                                       \
     if ((reinterpret_cast<void*>(diopiFunc) != nullptr) &&                   \
-        (!dipu::opRegexMatch::whetherOpMatch(                                \
-            opname, dipu::opRegexMatch::fallbackMatchers))) {                \
+        (!dipu::op_regex_match::isOpMatch(                                \
+            opname, dipu::op_regex_match::fallbackMatchers))) {                \
       m.impl(opname, TORCH_FN(wrapperFunc));                                 \
     } else {                                                                 \
       if ((reinterpret_cast<void*>(diopiFunc) == nullptr)) {                 \
@@ -98,9 +98,14 @@ void dipu_fallback(const c10::OperatorHandle& op, DispatchKeySet dispatch_keys,
     }                                                                         \
     if ((reinterpret_cast<void*>(diopi_func) != nullptr) &&                   \
         !((force_fallback) ||                                                 \
-          dipu::opRegexMatch::whetherOpMatch(                                 \
-              opname, dipu::opRegexMatch::fallbackMatchers))) {               \
-      m.impl(opname, TORCH_FN(wrapper_func));                                 \
+          dipu::op_regex_match::isOpMatch(                                 \
+              opname, dipu::op_regex_match::fallbackMatchers))) {               \
+      if (dipu::op_regex_match::isOpMatch(                                 \
+              opname, dipu::op_regex_match::autocompareMatchers)) {             \
+        m.impl(opname, TORCH_FN(wrapper_func##_autocompare));                 \
+      } else {                                                                \
+        m.impl(opname, TORCH_FN(wrapper_func));                               \
+      }                                                                       \
     } else {                                                                  \
       if ((reinterpret_cast<void*>(diopi_func) == nullptr)) {                 \
         DIPU_OP_LOG_WARNING_ONCE(#diopi_func << " is not yet implemented, "); \

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
@@ -35,6 +35,8 @@ enum class DIPUCopyType {
   D2H,
   // from host to device
   H2D,
+  // from host to host
+  H2H,
 };
 
 // Align with pytorch's behavior, see TensorIterator.cpp compute_mem_overlaps()
@@ -59,16 +61,23 @@ inline void tryRecordStream(const at::Tensor& tensor, DIPUStream& curStream,
 inline DIPUCopyType getCopyType(const at::Tensor& dst, const at::Tensor& src) {
   bool isSrcDevice = dipu::isDeviceTensor(src);
   bool isDstDevice = dipu::isDeviceTensor(dst);
-  if (!isSrcDevice) {
-    return DIPUCopyType::H2D;  // this op not handle h2h, dest always device
+  if (!isSrcDevice && isDstDevice) {
+    return DIPUCopyType::H2D;
   }
-  if (!isDstDevice) {
-    return DIPUCopyType::D2H;  // here src always device
+  if (!isDstDevice && isSrcDevice) {
+    return DIPUCopyType::D2H;
   }
-  if (src.device().index() != dst.device().index()) {
+  if (isSrcDevice && isDstDevice &&
+      src.device().index() != dst.device().index()) {
     return DIPUCopyType::D2OtherD;
   }
-  return DIPUCopyType::D2Self;
+  if (isSrcDevice && isDstDevice &&
+      src.device().index() == dst.device().index()) {
+    return DIPUCopyType::D2Self;
+  }
+  if (!isSrcDevice && !isDstDevice) {
+    return DIPUCopyType::H2H;
+  }
 }
 
 inline int64_t getMemCopyBytes(const at::Tensor& dst, const at::Tensor& src,
@@ -117,6 +126,17 @@ inline void doMemCopyD2H(const at::Tensor& dst, const at::Tensor& src,
   }
 }
 
+inline void doMemCopyH2H(const at::Tensor& dst, const at::Tensor& src,
+                         int64_t nbytes) {
+  if (!dst.is_contiguous() || !src.is_contiguous()) {
+    std::cerr << "Tensors must be contiguous for memory copy." << std::endl;
+    return;
+  }
+  void* src_ptr = src.data_ptr();
+  void* dst_ptr = dst.data_ptr();
+  memcpy(dst_ptr, src_ptr, nbytes);
+}
+
 inline void doMemCopyD2D(const at::Tensor& dst, const at::Tensor& src,
                          dipu::DIPUStream& stream, int64_t nbytes,
                          bool isSynchronousCopy) {
@@ -147,6 +167,9 @@ inline void memCopy(const at::Tensor& dst, const at::Tensor& src,
     case DIPUCopyType::D2H:
       // dst is cpu.
       doMemCopyD2H(dst, src, stream, nbytes, isSynchronousCopy);
+      break;
+    case DIPUCopyType::H2H:
+      doMemCopyH2H(dst, src, nbytes);
       break;
     default:  // device to device
       doMemCopyD2D(dst, src, stream, nbytes, isSynchronousCopy);
@@ -294,7 +317,6 @@ class DIPUCopyInplace : public DIPUCopyBase {
     if (native::dumpOpArgLevel() > 0) {
       printf("--%-50s %-30s \n", "[copy_]:", "doDirectMemCopy");
     }
-
     memCopy(dst, src, curStream, copyType, /*nonOverlappingAndDense=*/true,
             /*isSynchronousCopy=*/false);
 

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
@@ -78,6 +78,7 @@ inline DIPUCopyType getCopyType(const at::Tensor& dst, const at::Tensor& src) {
   if (!isSrcDevice && !isDstDevice) {
     return DIPUCopyType::H2H;
   }
+  return DIPUCopyType::H2H;
 }
 
 inline int64_t getMemCopyBytes(const at::Tensor& dst, const at::Tensor& src,

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -98,13 +98,13 @@ bool whetherAutoCompare(const char* opname,
 }
 }  // end of namespace dipu
 
-const char* fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
-const char* fallback_config_name = ".dipu_force_fallback_op_list.config";
+const char* const fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
+const char* const fallback_config_name = ".dipu_force_fallback_op_list.config";
 const std::vector<std::regex> fallbackMatchers =
     dipu::loadMatcher(fallback_env_name, fallback_config_name);
 
-const char* specified_autocompare_env_name = "SPECIFIED_AUTOCOMPARE_OPS_LIST";
-const char* specified_autocompare_config_name =
+const char* const specified_autocompare_env_name = "SPECIFIED_AUTOCOMPARE_OPS_LIST";
+const char* const specified_autocompare_config_name =
     ".specified_autocompare_op_list.config";
 const std::vector<std::regex> autocompareMatchers = dipu::loadMatcher(
     specified_autocompare_env_name, specified_autocompare_config_name);

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2024, DeepLink.
+#include "OpRegexMatch.hpp"
+
 #include <c10/util/Exception.h>
 
 #include <algorithm>
@@ -5,8 +8,6 @@
 #include <ios>
 #include <iostream>
 #include <regex>
-
-#include "OpRegexMatch.hpp"
 
 // loadMatcher is used to get regex matcher from env_name and config
 // fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST"; fallback_config_name =

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -67,7 +67,8 @@ constexpr const char* kFallbackConfigName =
 const std::vector<std::regex> fallbackMatchers =
     dipu::op_regex_match::loadMatcher(kFallbackEnvName, kFallbackConfigName);
 
-constexpr const char* kSpecifiedAutocompareEnvName = "DIPU_AUTOCOMPARE_OPS_LIST";
+constexpr const char* kSpecifiedAutocompareEnvName =
+    "DIPU_AUTOCOMPARE_OPS_LIST";
 constexpr const char* kSpecifiedAutocompareConfigName =
     ".specified_autocompare_op_list.config";
 const std::vector<std::regex> autocompareMatchers =

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -84,10 +84,8 @@ bool whetherAutoCompare(const char* opname, std::vector<std::regex> autocompareM
     return true;
   } 
   // else if opname in SPECIFIED_AUTOCOMPARE_OPS_LIST, the specified op will be autocomapred
-  // return whetherOpMatch(opname, autocompareMatchers);
-  return false;
-
-}
+  return whetherOpMatch(opname, autocompareMatchers);
+  }
 } // end of namespace dipu
 
 const char*  fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -51,7 +51,7 @@ std::vector<std::regex> loadMatcher(const char* env_name,
 }
 
 bool isOpMatch(const char* opname,
-                    const std::vector<std::regex>& regexMatchers) {
+               const std::vector<std::regex>& regexMatchers) {
   if (regexMatchers.empty() || opname == nullptr) {
     return false;
   }
@@ -71,6 +71,6 @@ const char* const specified_autocompare_config_name =
     ".specified_autocompare_op_list.config";
 const std::vector<std::regex> autocompareMatchers =
     dipu::op_regex_match::loadMatcher(specified_autocompare_env_name,
-                                    specified_autocompare_config_name);
+                                      specified_autocompare_config_name);
 }  // namespace op_regex_match
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -16,7 +16,7 @@
 // ".specified_autocompare_op_list.config"
 
 namespace dipu {
-namespace opRegexMatch {
+namespace op_regex_match {
 std::vector<std::regex> loadMatcher(const char* env_name,
                                     const char* config_name) {
   auto append = [](std::istream& input, std::vector<std::regex>& output) {
@@ -50,7 +50,7 @@ std::vector<std::regex> loadMatcher(const char* env_name,
   return list;
 }
 
-bool whetherOpMatch(const char* opname,
+bool isOpMatch(const char* opname,
                     const std::vector<std::regex>& regexMatchers) {
   if (regexMatchers.empty() || opname == nullptr) {
     return false;
@@ -64,13 +64,13 @@ bool whetherOpMatch(const char* opname,
 const char* const fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
 const char* const fallback_config_name = ".dipu_force_fallback_op_list.config";
 const std::vector<std::regex> fallbackMatchers =
-    dipu::opRegexMatch::loadMatcher(fallback_env_name, fallback_config_name);
+    dipu::op_regex_match::loadMatcher(fallback_env_name, fallback_config_name);
 
 const char* const specified_autocompare_env_name = "DIPU_AUTOCOMPARE_OPS_LIST";
 const char* const specified_autocompare_config_name =
     ".specified_autocompare_op_list.config";
 const std::vector<std::regex> autocompareMatchers =
-    dipu::opRegexMatch::loadMatcher(specified_autocompare_env_name,
+    dipu::op_regex_match::loadMatcher(specified_autocompare_env_name,
                                     specified_autocompare_config_name);
-}  // namespace opRegexMatch
+}  // namespace op_regex_match
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -1,13 +1,13 @@
 // Copyright (c) 2024, DeepLink.
 #include "OpRegexMatch.hpp"
 
-#include <c10/util/Exception.h>
-
 #include <algorithm>
 #include <fstream>
 #include <ios>
 #include <iostream>
 #include <regex>
+
+#include <c10/util/Exception.h>
 
 // loadMatcher is used to get regex matcher from env_name and config
 // fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST"; fallback_config_name =

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -103,7 +103,8 @@ const char* const fallback_config_name = ".dipu_force_fallback_op_list.config";
 const std::vector<std::regex> fallbackMatchers =
     dipu::loadMatcher(fallback_env_name, fallback_config_name);
 
-const char* const specified_autocompare_env_name = "SPECIFIED_AUTOCOMPARE_OPS_LIST";
+const char* const specified_autocompare_env_name =
+    "SPECIFIED_AUTOCOMPARE_OPS_LIST";
 const char* const specified_autocompare_config_name =
     ".specified_autocompare_op_list.config";
 const std::vector<std::regex> autocompareMatchers = dipu::loadMatcher(

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -10,9 +10,9 @@
 #include <c10/util/Exception.h>
 
 // loadMatcher is used to get regex matcher from env_name and config
-// fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST"; fallback_config_name =
-// ".dipu_force_fallback_op_list.config" specified_autocompare_env_name =
-// "DIPU_AUTOCOMPARE_OPS_LIST"; specified_autocompare_config_name =
+// fallbackEnvName = "DIPU_FORCE_FALLBACK_OPS_LIST"; fallbackConfigName =
+// ".dipu_force_fallback_op_list.config" specifiedAutocompareEnvName =
+// "DIPU_AUTOCOMPARE_OPS_LIST"; specifiedAutocompareConfigName =
 // ".specified_autocompare_op_list.config"
 
 namespace dipu {
@@ -61,16 +61,17 @@ bool isOpMatch(const char* opname,
       [&opname](auto& matcher) { return std::regex_match(opname, matcher); });
 }
 
-const char* const fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
-const char* const fallback_config_name = ".dipu_force_fallback_op_list.config";
+constexpr const char* fallbackEnvName = "DIPU_FORCE_FALLBACK_OPS_LIST";
+constexpr const char* fallbackConfigName =
+    ".dipu_force_fallback_op_list.config";
 const std::vector<std::regex> fallbackMatchers =
-    dipu::op_regex_match::loadMatcher(fallback_env_name, fallback_config_name);
+    dipu::op_regex_match::loadMatcher(fallbackEnvName, fallbackConfigName);
 
-const char* const specified_autocompare_env_name = "DIPU_AUTOCOMPARE_OPS_LIST";
-const char* const specified_autocompare_config_name =
+constexpr const char* specifiedAutocompareEnvName = "DIPU_AUTOCOMPARE_OPS_LIST";
+constexpr const char* specifiedAutocompareConfigName =
     ".specified_autocompare_op_list.config";
 const std::vector<std::regex> autocompareMatchers =
-    dipu::op_regex_match::loadMatcher(specified_autocompare_env_name,
-                                      specified_autocompare_config_name);
+    dipu::op_regex_match::loadMatcher(specifiedAutocompareEnvName,
+                                      specifiedAutocompareConfigName);
 }  // namespace op_regex_match
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -10,9 +10,9 @@
 #include <c10/util/Exception.h>
 
 // loadMatcher is used to get regex matcher from env_name and config
-// fallbackEnvName = "DIPU_FORCE_FALLBACK_OPS_LIST"; fallbackConfigName =
-// ".dipu_force_fallback_op_list.config" specifiedAutocompareEnvName =
-// "DIPU_AUTOCOMPARE_OPS_LIST"; specifiedAutocompareConfigName =
+// kFallbackEnvName = "DIPU_FORCE_FALLBACK_OPS_LIST"; kFallbackConfigName =
+// ".dipu_force_fallback_op_list.config" kSpecifiedAutocompareEnvName =
+// "DIPU_AUTOCOMPARE_OPS_LIST"; kSpecifiedAutocompareConfigName =
 // ".specified_autocompare_op_list.config"
 
 namespace dipu {
@@ -61,17 +61,17 @@ bool isOpMatch(const char* opname,
       [&opname](auto& matcher) { return std::regex_match(opname, matcher); });
 }
 
-constexpr const char* fallbackEnvName = "DIPU_FORCE_FALLBACK_OPS_LIST";
-constexpr const char* fallbackConfigName =
+constexpr const char* kFallbackEnvName = "DIPU_FORCE_FALLBACK_OPS_LIST";
+constexpr const char* kFallbackConfigName =
     ".dipu_force_fallback_op_list.config";
 const std::vector<std::regex> fallbackMatchers =
-    dipu::op_regex_match::loadMatcher(fallbackEnvName, fallbackConfigName);
+    dipu::op_regex_match::loadMatcher(kFallbackEnvName, kFallbackConfigName);
 
-constexpr const char* specifiedAutocompareEnvName = "DIPU_AUTOCOMPARE_OPS_LIST";
-constexpr const char* specifiedAutocompareConfigName =
+constexpr const char* kSpecifiedAutocompareEnvName = "DIPU_AUTOCOMPARE_OPS_LIST";
+constexpr const char* kSpecifiedAutocompareConfigName =
     ".specified_autocompare_op_list.config";
 const std::vector<std::regex> autocompareMatchers =
-    dipu::op_regex_match::loadMatcher(specifiedAutocompareEnvName,
-                                      specifiedAutocompareConfigName);
+    dipu::op_regex_match::loadMatcher(kSpecifiedAutocompareEnvName,
+                                      kSpecifiedAutocompareConfigName);
 }  // namespace op_regex_match
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -48,7 +48,8 @@ std::vector<std::regex> loadMatcher(const char* env_name,
   return list;
 }
 
-bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers) {
+bool whetherOpMatch(const char* opname,
+                    const std::vector<std::regex>& regexMatchers) {
   if (regexMatchers.empty() || opname == nullptr) {
     return false;
   }
@@ -59,7 +60,7 @@ bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers) {
 }
 
 bool whetherGlobalAutocompare() {
-  static const char* globalAutocompare = std::getenv("USE_GLOBAL_AUTOCOMPARE");
+  const char* globalAutocompare = std::getenv("USE_GLOBAL_AUTOCOMPARE");
   if (globalAutocompare == nullptr) {
     return false;
   }
@@ -84,7 +85,7 @@ bool whetherGlobalAutocompare() {
 // Whether to enable AutoCompare is based on USE_GLOBAL_AUTOCOMPARE and
 // SPECIFIED_AUTOCOMPARE_OPS_LIST
 bool whetherAutoCompare(const char* opname,
-                        std::vector<std::regex> autocompareMatchers) {
+                        const std::vector<std::regex>& autocompareMatchers) {
   // if USE_GLOBAL_AUTOCOMPARE is true, global autocompare is enabled regardless
   // the value of SPECIFIED_AUTOCOMPARE_OPS_LIST
   if (whetherGlobalAutocompare()) {
@@ -98,11 +99,11 @@ bool whetherAutoCompare(const char* opname,
 
 const char* fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
 const char* fallback_config_name = ".dipu_force_fallback_op_list.config";
-std::vector<std::regex> fallbackMatchers =
+const std::vector<std::regex> fallbackMatchers =
     dipu::loadMatcher(fallback_env_name, fallback_config_name);
 
 const char* specified_autocompare_env_name = "SPECIFIED_AUTOCOMPARE_OPS_LIST";
 const char* specified_autocompare_config_name =
     ".specified_autocompare_op_list.config";
-std::vector<std::regex> autocompareMatchers = dipu::loadMatcher(
+const std::vector<std::regex> autocompareMatchers = dipu::loadMatcher(
     specified_autocompare_env_name, specified_autocompare_config_name);

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -1,19 +1,22 @@
+#include <c10/util/Exception.h>
+
 #include <algorithm>
+#include <fstream>
 #include <ios>
 #include <iostream>
-#include <fstream>
 #include <regex>
-
-#include <c10/util/Exception.h>
 
 #include "OpRegexMatch.hpp"
 
 // loadMatcher is used to get regex matcher from env_name and config
-// fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST"; fallback_config_name = ".dipu_force_fallback_op_list.config"
-// specified_autocompare_env_name = "SPECIFIED_AUTOCOMPARE_OPS_LIST"; specified_autocompare_config_name = ".specified_autocompare_op_list.config"
+// fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST"; fallback_config_name =
+// ".dipu_force_fallback_op_list.config" specified_autocompare_env_name =
+// "SPECIFIED_AUTOCOMPARE_OPS_LIST"; specified_autocompare_config_name =
+// ".specified_autocompare_op_list.config"
 
 namespace dipu {
-std::vector<std::regex> loadMatcher(const char* env_name, const char* config_name) {
+std::vector<std::regex> loadMatcher(const char* env_name,
+                                    const char* config_name) {
   auto append = [](std::istream& input, std::vector<std::regex>& output) {
     auto constexpr separator = ',';
 
@@ -73,25 +76,33 @@ bool whetherGlobalAutocompare() {
     return false;
   }
 
-  std::cerr << "Error: USE_GLOBAL_AUTOCOMPARE can only be set to 'ON' or 'OFF'.\n";
+  std::cerr
+      << "Error: USE_GLOBAL_AUTOCOMPARE can only be set to 'ON' or 'OFF'.\n";
   return false;
 }
 
-// Whether to enable AutoCompare is based on USE_GLOBAL_AUTOCOMPARE and SPECIFIED_AUTOCOMPARE_OPS_LIST
-bool whetherAutoCompare(const char* opname, std::vector<std::regex> autocompareMatchers) {
-  // if USE_GLOBAL_AUTOCOMPARE is true, global autocompare is enabled regardless the value of SPECIFIED_AUTOCOMPARE_OPS_LIST
+// Whether to enable AutoCompare is based on USE_GLOBAL_AUTOCOMPARE and
+// SPECIFIED_AUTOCOMPARE_OPS_LIST
+bool whetherAutoCompare(const char* opname,
+                        std::vector<std::regex> autocompareMatchers) {
+  // if USE_GLOBAL_AUTOCOMPARE is true, global autocompare is enabled regardless
+  // the value of SPECIFIED_AUTOCOMPARE_OPS_LIST
   if (whetherGlobalAutocompare()) {
     return true;
-  } 
-  // else if opname in SPECIFIED_AUTOCOMPARE_OPS_LIST, the specified op will be autocomapred
-  return whetherOpMatch(opname, autocompareMatchers);
   }
-} // end of namespace dipu
+  // else if opname in SPECIFIED_AUTOCOMPARE_OPS_LIST, the specified op will be
+  // autocomapred
+  return whetherOpMatch(opname, autocompareMatchers);
+}
+}  // end of namespace dipu
 
-const char*  fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
-const char*  fallback_config_name = ".dipu_force_fallback_op_list.config";
-std::vector<std::regex> fallbackMatchers = dipu::loadMatcher(fallback_env_name, fallback_config_name);
+const char* fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
+const char* fallback_config_name = ".dipu_force_fallback_op_list.config";
+std::vector<std::regex> fallbackMatchers =
+    dipu::loadMatcher(fallback_env_name, fallback_config_name);
 
-const char* specified_autocompare_env_name = "SPECIFIED_AUTOCOMPARE_OPS_LIST"; 
-const char* specified_autocompare_config_name = ".specified_autocompare_op_list.config";
-std::vector<std::regex> autocompareMatchers = dipu::loadMatcher(specified_autocompare_env_name, specified_autocompare_config_name);
+const char* specified_autocompare_env_name = "SPECIFIED_AUTOCOMPARE_OPS_LIST";
+const char* specified_autocompare_config_name =
+    ".specified_autocompare_op_list.config";
+std::vector<std::regex> autocompareMatchers = dipu::loadMatcher(
+    specified_autocompare_env_name, specified_autocompare_config_name);

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -1,0 +1,99 @@
+#include <algorithm>
+#include <ios>
+#include <iostream>
+#include <fstream>
+#include <regex>
+
+#include <c10/util/Exception.h>
+
+#include "OpRegexMatch.hpp"
+
+// loadMatcher is used to get regex matcher from env_name and config
+// fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST"; fallback_config_name = ".dipu_force_fallback_op_list.config"
+// specified_autocompare_env_name = "SPECIFIED_AUTOCOMPARE_OPS_LIST"; specified_autocompare_config_name = ".specified_autocompare_op_list.config"
+
+namespace dipu {
+std::vector<std::regex> loadMatcher(const char* env_name, const char* config_name) {
+  auto append = [](std::istream& input, std::vector<std::regex>& output) {
+    auto constexpr separator = ',';
+
+    auto line = std::string();
+    while (std::getline(input, line)) {
+      auto buffer = std::istringstream(line);
+      auto pattern = std::string();
+      while (std::getline(buffer, pattern, separator)) {
+        if (pattern.empty()) {
+          continue;
+        }
+        try {
+          output.emplace_back(pattern);
+        } catch (const std::regex_error& e) {
+          TORCH_CHECK(false, e.what());
+        }
+      }
+    }
+  };
+
+  auto list = std::vector<std::regex>();
+  if (auto env = std::getenv(env_name)) {
+    auto iss = std::istringstream(env);
+    append(iss, list);
+  }
+  if (auto file = std::ifstream(config_name, std::ios::binary)) {
+    append(file, list);
+  }
+  return list;
+}
+
+bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers) {
+  if (regexMatchers.empty() || opname == nullptr) {
+    return false;
+  }
+
+  return std::any_of(
+      regexMatchers.begin(), regexMatchers.end(),
+      [&opname](auto& matcher) { return std::regex_match(opname, matcher); });
+}
+
+bool whetherGlobalAutocompare() {
+  static const char* globalAutocompare = std::getenv("USE_GLOBAL_AUTOCOMPARE");
+  if (globalAutocompare == nullptr) {
+    return false;
+  }
+
+  std::string globalAutocompareStr(globalAutocompare);
+  for (char& c : globalAutocompareStr) {
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+
+  if (globalAutocompareStr == "on") {
+    return true;
+  }
+  if (globalAutocompareStr == "off") {
+    return false;
+  }
+
+  std::cerr << "Error: USE_GLOBAL_AUTOCOMPARE can only be set to 'ON' or 'OFF'.\n";
+  return false;
+}
+
+// Whether to enable AutoCompare is based on USE_GLOBAL_AUTOCOMPARE and SPECIFIED_AUTOCOMPARE_OPS_LIST
+bool whetherAutoCompare(const char* opname, std::vector<std::regex> autocompareMatchers) {
+  // if USE_GLOBAL_AUTOCOMPARE is true, global autocompare is enabled regardless the value of SPECIFIED_AUTOCOMPARE_OPS_LIST
+  if (whetherGlobalAutocompare()) {
+    return true;
+  } 
+  // else if opname in SPECIFIED_AUTOCOMPARE_OPS_LIST, the specified op will be autocomapred
+  // return whetherOpMatch(opname, autocompareMatchers);
+  return false;
+
+}
+} // end of namespace dipu
+
+const char*  fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
+const char*  fallback_config_name = ".dipu_force_fallback_op_list.config";
+std::vector<std::regex> fallbackMatchers = dipu::loadMatcher(fallback_env_name, fallback_config_name);
+
+const char* specified_autocompare_env_name = "SPECIFIED_AUTOCOMPARE_OPS_LIST"; 
+const char* specified_autocompare_config_name = ".specified_autocompare_op_list.config";
+std::vector<std::regex> autocompareMatchers = dipu::loadMatcher(specified_autocompare_env_name, specified_autocompare_config_name);

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -12,10 +12,11 @@
 // loadMatcher is used to get regex matcher from env_name and config
 // fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST"; fallback_config_name =
 // ".dipu_force_fallback_op_list.config" specified_autocompare_env_name =
-// "SPECIFIED_AUTOCOMPARE_OPS_LIST"; specified_autocompare_config_name =
+// "DIPU_AUTOCOMPARE_OPS_LIST"; specified_autocompare_config_name =
 // ".specified_autocompare_op_list.config"
 
 namespace dipu {
+namespace opRegexMatch {
 std::vector<std::regex> loadMatcher(const char* env_name,
                                     const char* config_name) {
   auto append = [](std::istream& input, std::vector<std::regex>& output) {
@@ -60,52 +61,16 @@ bool whetherOpMatch(const char* opname,
       [&opname](auto& matcher) { return std::regex_match(opname, matcher); });
 }
 
-bool whetherGlobalAutocompare() {
-  const char* globalAutocompare = std::getenv("USE_GLOBAL_AUTOCOMPARE");
-  if (globalAutocompare == nullptr) {
-    return false;
-  }
-
-  std::string globalAutocompareStr(globalAutocompare);
-  for (char& c : globalAutocompareStr) {
-    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-  }
-
-  if (globalAutocompareStr == "on") {
-    return true;
-  }
-  if (globalAutocompareStr == "off") {
-    return false;
-  }
-
-  std::cerr
-      << "Error: USE_GLOBAL_AUTOCOMPARE can only be set to 'ON' or 'OFF'.\n";
-  return false;
-}
-
-// Whether to enable AutoCompare is based on USE_GLOBAL_AUTOCOMPARE and
-// SPECIFIED_AUTOCOMPARE_OPS_LIST
-bool whetherAutoCompare(const char* opname,
-                        const std::vector<std::regex>& autocompareMatchers) {
-  // if USE_GLOBAL_AUTOCOMPARE is true, global autocompare is enabled regardless
-  // the value of SPECIFIED_AUTOCOMPARE_OPS_LIST
-  if (whetherGlobalAutocompare()) {
-    return true;
-  }
-  // else if opname in SPECIFIED_AUTOCOMPARE_OPS_LIST, the specified op will be
-  // autocomapred
-  return whetherOpMatch(opname, autocompareMatchers);
-}
-}  // end of namespace dipu
-
 const char* const fallback_env_name = "DIPU_FORCE_FALLBACK_OPS_LIST";
 const char* const fallback_config_name = ".dipu_force_fallback_op_list.config";
 const std::vector<std::regex> fallbackMatchers =
-    dipu::loadMatcher(fallback_env_name, fallback_config_name);
+    dipu::opRegexMatch::loadMatcher(fallback_env_name, fallback_config_name);
 
-const char* const specified_autocompare_env_name =
-    "SPECIFIED_AUTOCOMPARE_OPS_LIST";
+const char* const specified_autocompare_env_name = "DIPU_AUTOCOMPARE_OPS_LIST";
 const char* const specified_autocompare_config_name =
     ".specified_autocompare_op_list.config";
-const std::vector<std::regex> autocompareMatchers = dipu::loadMatcher(
-    specified_autocompare_env_name, specified_autocompare_config_name);
+const std::vector<std::regex> autocompareMatchers =
+    dipu::opRegexMatch::loadMatcher(specified_autocompare_env_name,
+                                    specified_autocompare_config_name);
+}  // namespace opRegexMatch
+}  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.cpp
@@ -64,14 +64,14 @@ bool isOpMatch(const char* opname,
 constexpr const char* kFallbackEnvName = "DIPU_FORCE_FALLBACK_OPS_LIST";
 constexpr const char* kFallbackConfigName =
     ".dipu_force_fallback_op_list.config";
-const std::vector<std::regex> fallbackMatchers =
+const std::vector<std::regex> kFallbackMatchers =
     dipu::op_regex_match::loadMatcher(kFallbackEnvName, kFallbackConfigName);
 
 constexpr const char* kSpecifiedAutocompareEnvName =
     "DIPU_AUTOCOMPARE_OPS_LIST";
 constexpr const char* kSpecifiedAutocompareConfigName =
     ".specified_autocompare_op_list.config";
-const std::vector<std::regex> autocompareMatchers =
+const std::vector<std::regex> kAutocompareMatchers =
     dipu::op_regex_match::loadMatcher(kSpecifiedAutocompareEnvName,
                                       kSpecifiedAutocompareConfigName);
 }  // namespace op_regex_match

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -1,21 +1,23 @@
+#include <c10/util/Exception.h>
+
 #include <algorithm>
 #include <ios>
 #include <iostream>
 #include <regex>
 
-#include <c10/util/Exception.h>
-
-namespace dipu{
-std::vector<std::regex> loadMatcher(const char* env_name, const char* config_name);
+namespace dipu {
+std::vector<std::regex> loadMatcher(const char* env_name,
+                                    const char* config_name);
 bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers);
 bool whetherGlobalAutocompare();
-bool whetherAutoCompare(const char* opname, std::vector<std::regex> autocompareMatchers);
-}
+bool whetherAutoCompare(const char* opname,
+                        std::vector<std::regex> autocompareMatchers);
+}  // namespace dipu
 
-extern const char*  fallback_env_name;
-extern const char*  fallback_config_name;
+extern const char* fallback_env_name;
+extern const char* fallback_config_name;
 extern std::vector<std::regex> fallbackMatchers;
 
-extern const char* specified_autocompare_env_name; 
+extern const char* specified_autocompare_env_name;
 extern const char* specified_autocompare_config_name;
 extern std::vector<std::regex> autocompareMatchers;

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -12,13 +12,7 @@ std::vector<std::regex> loadMatcher(const char* env_name,
                                     const char* config_name);
 bool isOpMatch(const char* opname,
                const std::vector<std::regex>& regexMatchers);
-
-extern const char* const fallback_env_name;
-extern const char* const fallback_config_name;
 extern const std::vector<std::regex> fallbackMatchers;
-
-extern const char* const specified_autocompare_env_name;
-extern const char* const specified_autocompare_config_name;
 extern const std::vector<std::regex> autocompareMatchers;
 }  // namespace op_regex_match
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -7,10 +7,10 @@
 #include <c10/util/Exception.h>
 
 namespace dipu {
-namespace opRegexMatch {
+namespace op_regex_match {
 std::vector<std::regex> loadMatcher(const char* env_name,
                                     const char* config_name);
-bool whetherOpMatch(const char* opname,
+bool isOpMatch(const char* opname,
                     const std::vector<std::regex>& regexMatchers);
 
 extern const char* const fallback_env_name;
@@ -20,5 +20,5 @@ extern const std::vector<std::regex> fallbackMatchers;
 extern const char* const specified_autocompare_env_name;
 extern const char* const specified_autocompare_config_name;
 extern const std::vector<std::regex> autocompareMatchers;
-}  // namespace opRegexMatch
+}  // namespace op_regex_match
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -1,3 +1,4 @@
+// Copyright (c) 2024, DeepLink.
 #include <c10/util/Exception.h>
 
 #include <algorithm>

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -11,7 +11,7 @@ namespace op_regex_match {
 std::vector<std::regex> loadMatcher(const char* env_name,
                                     const char* config_name);
 bool isOpMatch(const char* opname,
-                    const std::vector<std::regex>& regexMatchers);
+               const std::vector<std::regex>& regexMatchers);
 
 extern const char* const fallback_env_name;
 extern const char* const fallback_config_name;

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -16,10 +16,10 @@ bool whetherAutoCompare(const char* opname,
                         const std::vector<std::regex>& autocompareMatchers);
 }  // namespace dipu
 
-extern const char* fallback_env_name;
-extern const char* fallback_config_name;
+extern const char* const fallback_env_name;
+extern const char* const fallback_config_name;
 extern const std::vector<std::regex> fallbackMatchers;
 
-extern const char* specified_autocompare_env_name;
-extern const char* specified_autocompare_config_name;
+extern const char* const specified_autocompare_env_name;
+extern const char* const specified_autocompare_config_name;
 extern const std::vector<std::regex> autocompareMatchers;

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -1,0 +1,21 @@
+#include <algorithm>
+#include <ios>
+#include <iostream>
+#include <regex>
+
+#include <c10/util/Exception.h>
+
+namespace dipu{
+std::vector<std::regex> loadMatcher(const char* env_name, const char* config_name);
+const bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers);
+bool whetherGlobalAutocompare();
+bool whetherAutoCompare(const char* opname, std::vector<std::regex> autocompareMatchers);
+}
+
+extern const char*  fallback_env_name;
+extern const char*  fallback_config_name;
+extern std::vector<std::regex> fallbackMatchers;
+
+extern const char* specified_autocompare_env_name; 
+extern const char* specified_autocompare_config_name;
+extern std::vector<std::regex> autocompareMatchers;

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -12,7 +12,7 @@ std::vector<std::regex> loadMatcher(const char* env_name,
                                     const char* config_name);
 bool isOpMatch(const char* opname,
                const std::vector<std::regex>& regexMatchers);
-extern const std::vector<std::regex> fallbackMatchers;
-extern const std::vector<std::regex> autocompareMatchers;
+extern const std::vector<std::regex> kFallbackMatchers;
+extern const std::vector<std::regex> kAutocompareMatchers;
 }  // namespace op_regex_match
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -1,10 +1,10 @@
 // Copyright (c) 2024, DeepLink.
-#include <c10/util/Exception.h>
-
 #include <algorithm>
 #include <ios>
 #include <iostream>
 #include <regex>
+
+#include <c10/util/Exception.h>
 
 namespace dipu {
 std::vector<std::regex> loadMatcher(const char* env_name,

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -7,14 +7,11 @@
 #include <c10/util/Exception.h>
 
 namespace dipu {
+namespace opRegexMatch {
 std::vector<std::regex> loadMatcher(const char* env_name,
                                     const char* config_name);
 bool whetherOpMatch(const char* opname,
                     const std::vector<std::regex>& regexMatchers);
-bool whetherGlobalAutocompare();
-bool whetherAutoCompare(const char* opname,
-                        const std::vector<std::regex>& autocompareMatchers);
-}  // namespace dipu
 
 extern const char* const fallback_env_name;
 extern const char* const fallback_config_name;
@@ -23,3 +20,5 @@ extern const std::vector<std::regex> fallbackMatchers;
 extern const char* const specified_autocompare_env_name;
 extern const char* const specified_autocompare_config_name;
 extern const std::vector<std::regex> autocompareMatchers;
+}  // namespace opRegexMatch
+}  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -8,16 +8,17 @@
 namespace dipu {
 std::vector<std::regex> loadMatcher(const char* env_name,
                                     const char* config_name);
-bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers);
+bool whetherOpMatch(const char* opname,
+                    const std::vector<std::regex>& regexMatchers);
 bool whetherGlobalAutocompare();
 bool whetherAutoCompare(const char* opname,
-                        std::vector<std::regex> autocompareMatchers);
+                        const std::vector<std::regex>& autocompareMatchers);
 }  // namespace dipu
 
 extern const char* fallback_env_name;
 extern const char* fallback_config_name;
-extern std::vector<std::regex> fallbackMatchers;
+extern const std::vector<std::regex> fallbackMatchers;
 
 extern const char* specified_autocompare_env_name;
 extern const char* specified_autocompare_config_name;
-extern std::vector<std::regex> autocompareMatchers;
+extern const std::vector<std::regex> autocompareMatchers;

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpRegexMatch.hpp
@@ -7,7 +7,7 @@
 
 namespace dipu{
 std::vector<std::regex> loadMatcher(const char* env_name, const char* config_name);
-const bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers);
+bool whetherOpMatch(const char* opname, std::vector<std::regex> regexMatchers);
 bool whetherGlobalAutocompare();
 bool whetherAutoCompare(const char* opname, std::vector<std::regex> autocompareMatchers);
 }


### PR DESCRIPTION
基于这个[PR](https://github.com/DeepLink-org/deeplink.framework/pull/785)进行修改，原来的PR保留为draft。
重构register机制，针对配置文件中的custom_fallback和autocmpare，定义了四个注册宏
生成的代码片段如下：
![image](https://github.com/DeepLink-org/deeplink.framework/assets/100055343/3a8cf442-a4fd-4b35-a4dc-6539ed8ec6ea)
