### PR TITLE
add get comm name for ascend

### DIFF
--- a/dipu/tests/python/individual_scripts/test_rt_ddp.py
+++ b/dipu/tests/python/individual_scripts/test_rt_ddp.py
@@ -381,6 +381,24 @@ def test_special_group_stuck(rank, world_size):
     cleanup()
 
 
+def test_get_comm_name(rank, world_size, port):
+    import torch_dipu
+
+    if torch_dipu.dipu.vendor_type == "NPU":
+        print(f"test get comm name on rank {rank} ")
+
+        setup(rank, world_size)
+
+        _ = torch.ones((2, 4)).to(rank)
+        group = dist.distributed_c10d._get_default_group()
+        device = dist.distributed_c10d._get_pg_default_device(group)
+        process_group_dicl = group._get_backend(device)
+        comm_name = process_group_dicl.get_comm_name(rank)
+        print(comm_name)
+
+        cleanup()
+
+
 if __name__ == "__main__":
     n_gpus = torch.cuda.device_count()
 
@@ -395,6 +413,8 @@ if __name__ == "__main__":
     run_demo(demo_reducescatter_base, world_size, port)
 
     run_demo(demo_allgather_gloo, world_size, port)
+
+    run_demo(test_get_comm_name, world_size, port)
 
     # need 2 card to run
     # run_demo(demo_p2p, world_size, port)

--- a/dipu/torch_dipu/csrc_dipu/binding/ExportRT.cpp
+++ b/dipu/torch_dipu/csrc_dipu/binding/ExportRT.cpp
@@ -227,7 +227,7 @@ static void exportCommunicator(py::module& m) {
            py::call_guard<py::gil_scoped_release>())
       .def("store", &ProcessGroupDICL::getStore)
       .def("get_comm_name",
-           [](ProcessGroupDICL& self, at::DeviceIndex device_index) {
+           [](ProcessGroupDICL& self, const at::DeviceIndex device_index) {
              return self.getCommName(device_index);
            })
       .def("timeout", [](ProcessGroupDICL& self) {

--- a/dipu/torch_dipu/csrc_dipu/binding/ExportRT.cpp
+++ b/dipu/torch_dipu/csrc_dipu/binding/ExportRT.cpp
@@ -227,7 +227,7 @@ static void exportCommunicator(py::module& m) {
            py::call_guard<py::gil_scoped_release>())
       .def("store", &ProcessGroupDICL::getStore)
       .def("get_comm_name",
-           [](ProcessGroupDICL& self, int device_index) {
+           [](ProcessGroupDICL& self, at::DeviceIndex device_index) {
              return self.getCommName(device_index);
            })
       .def("timeout", [](ProcessGroupDICL& self) {

--- a/dipu/torch_dipu/csrc_dipu/binding/ExportRT.cpp
+++ b/dipu/torch_dipu/csrc_dipu/binding/ExportRT.cpp
@@ -228,7 +228,7 @@ static void exportCommunicator(py::module& m) {
       .def("store", &ProcessGroupDICL::getStore)
       .def("get_comm_name",
            [](ProcessGroupDICL& self, const at::DeviceIndex device_index) {
-             return self.getCommName(device_index);
+             return std::string(self.getCommName(device_index));
            })
       .def("timeout", [](ProcessGroupDICL& self) {
         // need enhance to support tiemout

--- a/dipu/torch_dipu/csrc_dipu/binding/ExportRT.cpp
+++ b/dipu/torch_dipu/csrc_dipu/binding/ExportRT.cpp
@@ -226,6 +226,10 @@ static void exportCommunicator(py::module& m) {
            py::arg("timeout") = kBackendDefaultTimeout,
            py::call_guard<py::gil_scoped_release>())
       .def("store", &ProcessGroupDICL::getStore)
+      .def("get_comm_name",
+           [](ProcessGroupDICL& self, int device_index) {
+             return self.getCommName(device_index);
+           })
       .def("timeout", [](ProcessGroupDICL& self) {
         // need enhance to support tiemout
         return kBackendDefaultTimeout;

--- a/dipu/torch_dipu/csrc_dipu/runtime/device/diclapis.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/device/diclapis.h
@@ -67,7 +67,7 @@ DIPU_API diclResult_t diclRecv(void* recvBuf, size_t count,
                                at::ScalarType datatype, int peer,
                                diclComm_t comm, deviceStream_t stream);
 
-DIPU_API diclResult_t diclGetCommName(char* commName, diclComm_t comm);
+DIPU_WEAK diclResult_t diclGetCommName(char* commName, diclComm_t comm);
 
 }  // namespace devapis
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/device/diclapis.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/device/diclapis.h
@@ -67,7 +67,7 @@ DIPU_API diclResult_t diclRecv(void* recvBuf, size_t count,
                                at::ScalarType datatype, int peer,
                                diclComm_t comm, deviceStream_t stream);
 
-DIPU_WEAK diclResult_t diclGetCommName(char* commName, diclComm_t comm);
+DIPU_WEAK diclResult_t diclGetCommName(std::string& commName, diclComm_t comm);
 
 }  // namespace devapis
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/device/diclapis.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/device/diclapis.h
@@ -67,6 +67,8 @@ DIPU_API diclResult_t diclRecv(void* recvBuf, size_t count,
                                at::ScalarType datatype, int peer,
                                diclComm_t comm, deviceStream_t stream);
 
+DIPU_API diclResult_t diclGetCommName(char* commName, diclComm_t comm);
+
 }  // namespace devapis
 
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
@@ -75,7 +75,10 @@ devapis::diclResult_t diclRecv(void* recvbuff, size_t count,
 }
 
 devapis::diclResult_t diclGetCommName(char* commName, diclComm_t comm) {
-  return devapis::diclGetCommName(commName, comm);
+  if (devapis::diclGetCommName) {
+    return devapis::diclGetCommName(commName, comm);
+  }
+  return {};
 }
 
 }  // namespace devproxy

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
@@ -74,7 +74,7 @@ devapis::diclResult_t diclRecv(void* recvbuff, size_t count,
   return devapis::diclRecv(recvbuff, count, datatype, peer, comm, stream);
 }
 
-devapis::diclResult_t diclGetCommName(char* commName, diclComm_t comm) {
+devapis::diclResult_t diclGetCommName(std::string& commName, diclComm_t comm) {
   if (devapis::diclGetCommName) {
     return devapis::diclGetCommName(commName, comm);
   }

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
@@ -74,5 +74,9 @@ devapis::diclResult_t diclRecv(void* recvbuff, size_t count,
   return devapis::diclRecv(recvbuff, count, datatype, peer, comm, stream);
 }
 
+devapis::diclResult_t diclGetCommName(char* commName, diclComm_t comm) {
+  return devapis::diclGetCommName(commName, comm);
+}
+
 }  // namespace devproxy
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
@@ -78,7 +78,7 @@ devapis::diclResult_t diclGetCommName(std::string& commName, diclComm_t comm) {
   if (devapis::diclGetCommName) {
     return devapis::diclGetCommName(commName, comm);
   }
-  return {};
+  TORCH_CHECK(false, "device not implement diclGetCommName");
 }
 
 }  // namespace devproxy

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
@@ -51,5 +51,7 @@ DIPU_API devapis::diclResult_t diclRecv(void* recvbuff, size_t count,
                                         at::ScalarType datatype, int peer,
                                         diclComm_t comm, deviceStream_t stream);
 
+DIPU_API devapis::diclResult_t diclGetCommName(char* commName, diclComm_t comm);
+
 }  // namespace devproxy
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
@@ -51,7 +51,7 @@ DIPU_API devapis::diclResult_t diclRecv(void* recvbuff, size_t count,
                                         at::ScalarType datatype, int peer,
                                         diclComm_t comm, deviceStream_t stream);
 
-DIPU_WEAK devapis::diclResult_t diclGetCommName(char* commName,
+DIPU_WEAK devapis::diclResult_t diclGetCommName(std::string& commName,
                                                 diclComm_t comm);
 
 }  // namespace devproxy

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
@@ -51,7 +51,8 @@ DIPU_API devapis::diclResult_t diclRecv(void* recvbuff, size_t count,
                                         at::ScalarType datatype, int peer,
                                         diclComm_t comm, deviceStream_t stream);
 
-DIPU_API devapis::diclResult_t diclGetCommName(char* commName, diclComm_t comm);
+DIPU_WEAK devapis::diclResult_t diclGetCommName(char* commName,
+                                                diclComm_t comm);
 
 }  // namespace devproxy
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/DICLUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/DICLUtils.hpp
@@ -41,6 +41,12 @@ class DICLComm {
     return comm;
   }
 
+  std::string getName() {
+    std::vector<char> commName(128);
+    devproxy::diclGetCommName(commName.data(), rawComm_);
+    return std::string(commName.data());
+  }
+
   // Must not be copyable
   DICLComm(const DICLComm&) = delete;
   DICLComm& operator=(const DICLComm&) = delete;

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/DICLUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/DICLUtils.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <optional>
+#include <string_view>
 
 #include <c10/core/Device.h>
 
@@ -12,8 +13,6 @@
 #include "csrc_dipu/runtime/devproxy/diclproxy.h"
 
 namespace dipu {
-
-constexpr const int MAX_COMM_NAME_LENGTH = 128;
 
 // wrapper of vendor raw communicator
 class DICLComm {
@@ -44,13 +43,12 @@ class DICLComm {
     return comm;
   }
 
-  std::string getName() {
+  std::string_view getName() {
     if (!rawCommName) {
-      std::array<char, MAX_COMM_NAME_LENGTH> commName{};
-      devproxy::diclGetCommName(commName.data(), rawComm_);
-      rawCommName = std::string(commName.data());
+      rawCommName.emplace();
+      devproxy::diclGetCommName(*rawCommName, rawComm_);
     }
-    return *rawCommName;
+    return {*rawCommName};
   }
 
   // Must not be copyable

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/DICLUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/DICLUtils.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <algorithm>
+#include <optional>
 
 #include <c10/core/Device.h>
 
@@ -44,9 +45,12 @@ class DICLComm {
   }
 
   std::string getName() {
-    std::vector<char> commName(MAX_COMM_NAME_LENGTH);
-    devproxy::diclGetCommName(commName.data(), rawComm_);
-    return {commName.data()};
+    if (!rawCommName) {
+      std::array<char, MAX_COMM_NAME_LENGTH> commName{};
+      devproxy::diclGetCommName(commName.data(), rawComm_);
+      rawCommName = std::string(commName.data());
+    }
+    return *rawCommName;
   }
 
   // Must not be copyable
@@ -82,6 +86,7 @@ class DICLComm {
   bool aborted_ = false;
   diclComm_t rawComm_ = nullptr;
   mutable std::mutex mutex_;
+  std::optional<std::string> rawCommName;
 };
 
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/DICLUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/DICLUtils.hpp
@@ -12,6 +12,8 @@
 
 namespace dipu {
 
+constexpr const int MAX_COMM_NAME_LENGTH = 128;
+
 // wrapper of vendor raw communicator
 class DICLComm {
  private:
@@ -42,9 +44,9 @@ class DICLComm {
   }
 
   std::string getName() {
-    std::vector<char> commName(128);
+    std::vector<char> commName(MAX_COMM_NAME_LENGTH);
     devproxy::diclGetCommName(commName.data(), rawComm_);
-    return std::string(commName.data());
+    return {commName.data()};
   }
 
   // Must not be copyable

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -559,7 +559,6 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::gather(
   TORCH_CHECK(false, "ProcessGroupDICL does not support gather now");
 }
 
-// NOLINTNEXTLINE(google-default-arguments)
 std::string_view ProcessGroupDICL::getCommName(
     const at::DeviceIndex device_index) {
   auto device = at::Device(dipu::DIPU_DEVICE_TYPE, device_index);

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -254,7 +254,8 @@ std::vector<std::shared_ptr<DICLComm>>& ProcessGroupDICL::getDICLComms(
 }
 
 std::vector<std::shared_ptr<DICLComm>>& ProcessGroupDICL::getOrCreateDICLComm(
-    const std::string& localCommsKey, const std::vector<at::Device>& devices, int commsRank) {
+    const std::string& localCommsKey, const std::vector<at::Device>& devices,
+    int commsRank) {
   // Sanity check
   if (localCommsKey.empty()) {
     throw std::runtime_error(
@@ -605,14 +606,13 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::gather(
 }
 
 // NOLINTNEXTLINE(google-default-arguments)
-std::string ProcessGroupDICL::getCommName(int device_index) {
+std::string ProcessGroupDICL::getCommName(at::DeviceIndex device_index) {
   auto device = at::Device(dipu::DIPU_DEVICE_TYPE, device_index);
   std::vector<at::Device> devices{device};
-  const auto localCommsKey = getDevieceIds(devices);
+  const auto localCommsKey = getDeviceIds(devices);
   auto diclComms = getOrCreateDICLComm(localCommsKey, devices, this->rank_);
   return diclComms[0]->getName();
 }
-
 
 // NOLINTNEXTLINE(google-default-arguments)
 c10::intrusive_ptr<Work> ProcessGroupDICL::allgather(

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -560,7 +560,8 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::gather(
 }
 
 // NOLINTNEXTLINE(google-default-arguments)
-std::string ProcessGroupDICL::getCommName(const at::DeviceIndex device_index) {
+std::string_view ProcessGroupDICL::getCommName(
+    const at::DeviceIndex device_index) {
   auto device = at::Device(dipu::DIPU_DEVICE_TYPE, device_index);
   std::vector<at::Device> devices{device};
   const auto localCommsKey = getDeviceIds(devices);

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -253,52 +253,6 @@ std::vector<std::shared_ptr<DICLComm>>& ProcessGroupDICL::getDICLComms(
   return devDICLCommsMap_[localCommsKey];
 }
 
-std::vector<std::shared_ptr<DICLComm>>& ProcessGroupDICL::getOrCreateDICLComm(
-    const std::string& localCommsKey, const std::vector<at::Device>& devices,
-    int commsRank) {
-  // Sanity check
-  if (localCommsKey.empty()) {
-    throw std::runtime_error(
-        "Not able to create/get the DICL Communicator since "
-        "the DIPU devices are not known");
-  }
-  {
-    std::lock_guard<std::mutex> lock(devDICLCommMapLock_);
-    auto it = devDICLCommsMap_.find(localCommsKey);
-    if (it != devDICLCommsMap_.end()) {
-      return it->second;
-    }
-  }
-  // not cached, create a new entry
-  std::vector<std::shared_ptr<DICLComm>> diclComms;
-  int devSize = static_cast<int>(devices.size());
-  diclComms.resize(devSize);
-  int deviceWorldSize = getSize() * devSize;
-
-  commUniqueId diclID;
-  if (commsRank == 0) {
-    devproxy::diclGetUniqueId(&diclID);
-  }
-
-  std::string bcastKey = std::to_string(diclCommCounter_++);
-  broadcastUniqueID(&diclID, bcastKey, commsRank);
-
-  OptionalDIPUGuard dipuGuard;
-  for (int i = 0; i < devSize; i++) {
-    int deviceCommRank = getRank() * devSize + i;
-    dipuGuard.reset_device(devices[i]);
-    auto commStream = getDIPUStreamFromPool(devices[i].index());
-    diclComms[i] =
-        DICLComm::create(deviceWorldSize, deviceCommRank, diclID, commStream);
-  }
-
-  {
-    std::lock_guard<std::mutex> lock(devDICLCommMapLock_);
-    devDICLCommsMap_.emplace(localCommsKey, std::move(diclComms));
-    return devDICLCommsMap_[localCommsKey];
-  }
-}
-
 namespace {
 
 // Flatten each list in `tensor_lists' for a gather or scatter operation, and
@@ -610,7 +564,8 @@ std::string ProcessGroupDICL::getCommName(at::DeviceIndex device_index) {
   auto device = at::Device(dipu::DIPU_DEVICE_TYPE, device_index);
   std::vector<at::Device> devices{device};
   const auto localCommsKey = getDeviceIds(devices);
-  auto diclComms = getOrCreateDICLComm(localCommsKey, devices, this->rank_);
+  auto diclComms =
+      getDICLComms(localCommsKey, devices, this->rank_, OpType::UNKNOWN);
   return diclComms[0]->getName();
 }
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -560,7 +560,7 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::gather(
 }
 
 // NOLINTNEXTLINE(google-default-arguments)
-std::string ProcessGroupDICL::getCommName(at::DeviceIndex device_index) {
+std::string ProcessGroupDICL::getCommName(const at::DeviceIndex device_index) {
   auto device = at::Device(dipu::DIPU_DEVICE_TYPE, device_index);
   std::vector<at::Device> devices{device};
   const auto localCommsKey = getDeviceIds(devices);

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
@@ -230,10 +230,6 @@ class DIPU_API ProcessGroupDICL : public Backend {
       const std::string& localCommsKey, const std::vector<at::Device>& devices,
       int commsRank, OpType opType);
 
-  virtual std::vector<std::shared_ptr<DICLComm>>& getOrCreateDICLComm(
-      const std::string& localCommsKey, const std::vector<at::Device>& devices,
-      int commsRank);
-
   template <typename Fn>
   c10::intrusive_ptr<Work> collective(std::vector<at::Tensor>& input,
                                       std::vector<at::Tensor>& output, Fn fn,

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
@@ -167,7 +167,6 @@ class DIPU_API ProcessGroupDICL : public Backend {
     return DICL_BACKEND_NAME;
   }
 
-  // NOLINTNEXTLINE(readability-const-return-type) just follow parent class.
   std::string getCommName(at::DeviceIndex device_index);
 
   c10::intrusive_ptr<Work> broadcast(

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <chrono>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -167,7 +168,7 @@ class DIPU_API ProcessGroupDICL : public Backend {
     return DICL_BACKEND_NAME;
   }
 
-  std::string getCommName(at::DeviceIndex device_index);
+  std::string_view getCommName(at::DeviceIndex device_index);
 
   c10::intrusive_ptr<Work> broadcast(
       std::vector<at::Tensor>& tensors,

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
@@ -167,6 +167,9 @@ class DIPU_API ProcessGroupDICL : public Backend {
     return DICL_BACKEND_NAME;
   }
 
+  // NOLINTNEXTLINE(readability-const-return-type) just follow parent class.
+  std::string getCommName(int device_index);
+
   c10::intrusive_ptr<Work> broadcast(
       std::vector<at::Tensor>& tensors,
       const BroadcastOptions& opts /* = BroadcastOptions() */) override;
@@ -226,6 +229,10 @@ class DIPU_API ProcessGroupDICL : public Backend {
   virtual std::vector<std::shared_ptr<DICLComm>>& getDICLComms(
       const std::string& localCommsKey, const std::vector<at::Device>& devices,
       int commsRank, OpType opType);
+
+  virtual std::vector<std::shared_ptr<DICLComm>>& getOrCreateDICLComm(
+      const std::string& localCommsKey, const std::vector<at::Device>& devices,
+      int commsRank);
 
   template <typename Fn>
   c10::intrusive_ptr<Work> collective(std::vector<at::Tensor>& input,

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
@@ -168,7 +168,7 @@ class DIPU_API ProcessGroupDICL : public Backend {
   }
 
   // NOLINTNEXTLINE(readability-const-return-type) just follow parent class.
-  std::string getCommName(int device_index);
+  std::string getCommName(at::DeviceIndex device_index);
 
   c10::intrusive_ptr<Work> broadcast(
       std::vector<at::Tensor>& tensors,

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/communicatorimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/communicatorimpl.cpp
@@ -14,6 +14,8 @@
 namespace dipu {
 namespace devapis {
 
+constexpr const int MAX_COMM_NAME_LENGTH = 128;
+
 // HCCL ReduceOp mapping
 static std::map<c10d::ReduceOp, HcclReduceOp> hcclOp = {
     {ReduceOp::MIN, HCCL_REDUCE_MIN},
@@ -170,8 +172,10 @@ DIPU_API diclResult_t diclBroadcast(const void* sendBuf, void* recvBuf,
   return DICL_SUCCESS;
 }
 
-DIPU_API diclResult_t diclGetCommName(char* commName, diclComm_t comm) {
-  HCCL_THROW(HcclGetCommName(comm, commName));
+DIPU_API diclResult_t diclGetCommName(std::string& commName, diclComm_t comm) {
+  std::array<char, MAX_COMM_NAME_LENGTH> commName_{};
+  HCCL_THROW(HcclGetCommName(comm, commName_.data()));
+  commName = std::string{commName_.data()};
   return DICL_SUCCESS;
 }
 

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/communicatorimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/communicatorimpl.cpp
@@ -170,5 +170,10 @@ DIPU_API diclResult_t diclBroadcast(const void* sendBuf, void* recvBuf,
   return DICL_SUCCESS;
 }
 
+DIPU_API diclResult_t diclGetCommName(char* commName, diclComm_t comm) {
+  HCCL_THROW(HcclGetCommName(comm, commName));
+  return DICL_SUCCESS;
+}
+
 }  // end namespace devapis
 }  // end namespace dipu


### PR DESCRIPTION
增加获取当前集合通信操作所在的通信域的名称的功能，调用的cann接口为：
https://www.hiascend.com/document/detail/zh/canncommercial/80RC1/apiref/hcclapiref/hcclcpp_07_0012.html。