### PR TITLE
feat(dipu): use internal clangd-tidy when running ci

### DIFF
--- a/.github/workflows/_runs-on-nv-step1.yml
+++ b/.github/workflows/_runs-on-nv-step1.yml
@@ -60,6 +60,7 @@ jobs:
       DEEPLINK_PATH: ${{ inputs.deeplink_path }}
       ENV_PATH: ${{ inputs.env_path }}
       CUDA_PARTATION: "pat_dev"
+      CLANGD_TIDY_PATH: "/mnt/cache/share/platform/dep/clangd-tidy"
     steps:
       - name: Check SupportedDiopiFunctions.txt
         run: |
@@ -77,9 +78,9 @@ jobs:
       - name: Run clang-tidy
         run: |
           if [[ "${GETRUNNER}" == *sco* ]];then
-            srun --job-name=$GITHUB_JOB bash -c "bash $DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh"
+            srun --job-name=$GITHUB_JOB bash -c "bash $DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh $CLANGD_TIDY_PATH"
           else
             ssh SH1424 """
-            bash $DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh
+            bash $DEEPLINK_PATH/$GITHUB_RUN_NUMBER/Build-Cuda/dipu/scripts/ci/nv/ci_nv_tidy.sh $CLANGD_TIDY_PATH
             """
           fi

--- a/dipu/scripts/ci/nv/ci_nv_tidy.sh
+++ b/dipu/scripts/ci/nv/ci_nv_tidy.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Get current folder.
 self=$(dirname "$(realpath -s "${BASH_SOURCE[0]}")")
 repo=$(cd "$self" && git rev-parse --show-toplevel)
-tidy={1:-$self/clangd-tidy}
+tidy=${1:-$self/clangd-tidy}
 
 # Download clangd-tidy scripts.
 [ -d "$tidy" ] ||

--- a/dipu/scripts/ci/nv/ci_nv_tidy.sh
+++ b/dipu/scripts/ci/nv/ci_nv_tidy.sh
@@ -15,12 +15,13 @@ set -euo pipefail
 # Get current folder.
 self=$(dirname "$(realpath -s "${BASH_SOURCE[0]}")")
 repo=$(cd "$self" && git rev-parse --show-toplevel)
+tidy={1:-$self/clangd-tidy}
 
 # Download clangd-tidy scripts.
-[ -d "$self/clangd-tidy" ] ||
-    git -c advice.detachedHead=false clone --depth 1 -b v0.1.2 https://github.com/lljbash/clangd-tidy.git "$self/clangd-tidy"
+[ -d "$tidy" ] ||
+    git -c advice.detachedHead=false clone --depth 1 -b v0.2.0 https://github.com/lljbash/clangd-tidy.git "$tidy"
 
 # Collect source files and run tidy.
 (cd "$repo/dipu" &&
     find torch_dipu ! -path '*/vendor/*' ! -name 'AutoGenedKernels.cpp' \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) |
-    xargs "$self/clangd-tidy/clangd-tidy" -j4)
+    xargs "$tidy/clangd-tidy" -j4)

--- a/dipu/scripts/ci/nv/ci_nv_tidy.sh
+++ b/dipu/scripts/ci/nv/ci_nv_tidy.sh
@@ -27,6 +27,6 @@ echo "check clangd-tidy"
 echo "start clangd-tidy"
 (cd "$repo/dipu" &&
     find torch_dipu ! -path '*/vendor/*' ! -name 'AutoGenedKernels.cpp' \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) |
-    xargs "$tidy/clangd-tidy" --github --git-root="$repo" -j4 "$tlog")
+    xargs "$tidy/clangd-tidy" -j4 "$tlog") # TODO(wy,llj) --github --git-root="$repo"
 
 echo "all done"

--- a/dipu/scripts/ci/nv/ci_nv_tidy.sh
+++ b/dipu/scripts/ci/nv/ci_nv_tidy.sh
@@ -16,12 +16,17 @@ set -euo pipefail
 self=$(dirname "$(realpath -s "${BASH_SOURCE[0]}")")
 repo=$(cd "$self" && git rev-parse --show-toplevel)
 tidy=${1:-$self/clangd-tidy}
+tlog=${2:+-o\ $2}
 
 # Download clangd-tidy scripts.
+echo "check clangd-tidy"
 [ -d "$tidy" ] ||
     git -c advice.detachedHead=false clone --depth 1 -b v0.2.0 https://github.com/lljbash/clangd-tidy.git "$tidy"
 
 # Collect source files and run tidy.
+echo "start clangd-tidy"
 (cd "$repo/dipu" &&
     find torch_dipu ! -path '*/vendor/*' ! -name 'AutoGenedKernels.cpp' \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \) |
-    xargs "$tidy/clangd-tidy" -j4)
+    xargs "$tidy/clangd-tidy" --github --git-root="$repo" -j4 "$tlog")
+
+echo "all done"


### PR DESCRIPTION
虽然 clangd-tidy 仓库很小，但网络情况似乎不太好经常 clone 失败。这里新增参数，允许直接使用某个路径的 clangd-tidy