### PR TITLE
[DIPU] New implementation for AsyncResourcePoolImpl providing a separate queue for each stream

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUEvent.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUEvent.h
@@ -54,6 +54,7 @@ class DIPU_API DIPUEvent {
 
   bool isCreated() const { return event_ != nullptr; }
   c10::DeviceIndex device_index() const { return device_index_; }
+  c10::StreamId stream_id() const { return stream_id_; }
   deviceEvent_t rawevent() const { return event_; }
 
   bool query() const {
@@ -75,7 +76,7 @@ class DIPU_API DIPUEvent {
 
   void record(const DIPUStream& stream) {
     if (!isCreated()) {
-      createEvent(stream.device_index());
+      createEvent(stream);
     }
     TORCH_CHECK(device_index_ == stream.device_index(), "Event device ",
                 device_index_, " does not match recording stream's device ",
@@ -113,10 +114,12 @@ class DIPU_API DIPUEvent {
   unsigned int flags_ = 0;
   bool was_recorded_ = false;
   c10::DeviceIndex device_index_ = -1;
+  c10::StreamId stream_id_ = -1;
   deviceEvent_t event_ = nullptr;
 
-  void createEvent(c10::DeviceIndex device_index) {
-    device_index_ = device_index;
+  void createEvent(const DIPUStream& stream) {
+    device_index_ = stream.device_index();
+    stream_id_ = stream.id();
     DIPUGuard guard(device_index_);
     devproxy::createEvent(&event_);
   }

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUEvent.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUEvent.h
@@ -17,21 +17,14 @@ namespace dipu {
 class DIPU_API DIPUEvent {
  public:
   // Constructors
-  // Default value for `flags` is specified below
   DIPUEvent() = default;
-
-  // add flags in future
-  // DIPUEvent(unsigned int flags) : flags_{flags} {}
 
   // dipu do not support IpcEventHandle until now
 
   ~DIPUEvent() {
-    try {
-      if (isCreated()) {
-        DIPUGuard guard(device_index_);
-        devproxy::destroyEvent(event_);
-      }
-    } catch (...) { /* No throw */
+    if (isCreated()) {
+      DIPUGuard guard(device_index_);
+      devproxy::destroyEvent(event_);
     }
   }
 
@@ -42,7 +35,6 @@ class DIPU_API DIPUEvent {
 
   DIPUEvent& operator=(DIPUEvent&& other) noexcept {
     if (this != &other) {
-      flags_ = other.flags_;
       device_index_ = other.device_index_;
       stream_id_ = other.stream_id_;
       event_ = other.event_;
@@ -121,7 +113,6 @@ class DIPU_API DIPUEvent {
   // dipu do not support IpcEventHandle until now
 
  private:
-  unsigned int flags_ = 0;
   c10::DeviceIndex device_index_ = -1;
   c10::StreamId stream_id_ = -1;
   deviceEvent_t event_ = nullptr;

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUEvent.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/DIPUEvent.h
@@ -38,8 +38,18 @@ class DIPU_API DIPUEvent {
   DIPUEvent(const DIPUEvent&) = delete;
   DIPUEvent& operator=(const DIPUEvent&) = delete;
 
-  DIPUEvent(DIPUEvent&& other) noexcept = default;
-  DIPUEvent& operator=(DIPUEvent&& other) noexcept = default;
+  DIPUEvent(DIPUEvent&& other) noexcept { *this = std::move(other); }
+
+  DIPUEvent& operator=(DIPUEvent&& other) noexcept {
+    if (this != &other) {
+      flags_ = other.flags_;
+      device_index_ = other.device_index_;
+      stream_id_ = other.stream_id_;
+      event_ = other.event_;
+      other.event_ = nullptr;
+    }
+    return *this;
+  }
 
   explicit operator deviceEvent_t() const { return rawevent(); }
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
@@ -74,8 +74,9 @@ class AsyncResourcePoolImpl : public AsyncResourcePool<T> {
   }
 };
 
-template <class T, at::DeviceType device_type, int algorithm>
-class AsyncResourceMultiStreamPoolImpl : public AsyncResourcePool<T> {
+// This implementation provides a separate queue for each stream
+template <class T, at::DeviceType device_type>
+class AsyncResourcePoolImpl<T, device_type, 1> : public AsyncResourcePool<T> {
  private:
   struct Resource final {
     const T t;

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
@@ -101,7 +101,7 @@ class AsyncResourcePoolImpl<T, device_type, 1> : public AsyncResourcePool<T> {
   // Place them in a special queue for higher performance.
   std::queue<T> queue_without_events;
 
-  size_t total_size;
+  size_t total_size = 0;
 
   using mutex_t = std::mutex;
   mutable mutex_t mutex;
@@ -112,7 +112,7 @@ class AsyncResourcePoolImpl<T, device_type, 1> : public AsyncResourcePool<T> {
     if (events.empty()) {
       queue_without_events.push(t);
     } else {
-      Resource* resource = new Resource(t, events.size(), events);
+      auto resource = new Resource(t, events.size(), events);
       for (int i = 0; i < resource->event_count; ++i) {
         queues_with_events[resource->events[i].stream_id()].emplace(resource,
                                                                     i);

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <queue>
 #include <tuple>
+#include <utility>
 
 #include <c10/util/Exception.h>
 #include <c10/util/flat_hash_map.h>
@@ -115,6 +116,7 @@ class AsyncResourcePoolImpl<T, device_type, 1> : public AsyncResourcePool<T> {
         queues_with_events[event.stream_id()].emplace(resource,
                                                       std::move(event));
       }
+      events.clear();
     }
     ++total_size;
   }

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
@@ -139,7 +139,7 @@ class AsyncResourcePoolImpl<T, device_type, 1> : public AsyncResourcePool<T> {
 
   bool empty() const override {
     std::lock_guard<mutex_t> lk(mutex);
-    return total_size > 0;
+    return 0 == total_size;
   }
 
   // If there is no ready resource, remove completed events in queues

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
@@ -113,7 +113,7 @@ class AsyncResourcePoolImpl<T, device_type, 1> : public AsyncResourcePool<T> {
       auto resource = new Resource(t, events.size());
       for (DIPUEvent& event : events) {
         queues_with_events[event.stream_id()].emplace(resource,
-                                                        std::move(event));
+                                                      std::move(event));
       }
     }
     ++total_size;

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
@@ -74,9 +74,12 @@ class AsyncResourcePoolImpl : public AsyncResourcePool<T> {
   }
 };
 
+#define OneStreamOneQueueAlgo 1
+
 // This implementation provides a separate queue for each stream
 template <class T, at::DeviceType device_type>
-class AsyncResourcePoolImpl<T, device_type, 1> : public AsyncResourcePool<T> {
+class AsyncResourcePoolImpl<T, device_type, OneStreamOneQueueAlgo>
+    : public AsyncResourcePool<T> {
  private:
   // Resources that have events to wait for
   struct Resource final {

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
@@ -77,13 +77,19 @@ class AsyncResourcePoolImpl : public AsyncResourcePool<T> {
 template <class T, at::DeviceType device_type, int algorithm>
 class AsyncResourceMultiStreamPoolImpl : public AsyncResourcePool<T> {
  private:
-  struct Resource {
+  struct Resource final {
     const T t;
     int event_count;
     const std::deque<DIPUEvent> events;
 
     Resource(const T& t, int event_count, std::deque<DIPUEvent>& events)
         : t(t), event_count(event_count), events(std::move(events)) {}
+
+    ~Resource() = default;
+    Resource(const Resource&) = delete;
+    Resource& operator=(const Resource&) = delete;
+    Resource(Resource&&) = delete;
+    Resource& operator=(Resource&&) = delete;
   };
   ska::flat_hash_map<c10::StreamId,
                      std::queue<std::pair<std::shared_ptr<Resource>, int>>>

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
@@ -2,8 +2,13 @@
 #pragma once
 
 #include <deque>
+#include <memory>
 #include <mutex>
+#include <queue>
 #include <tuple>
+
+#include <c10/util/Exception.h>
+#include <c10/util/flat_hash_map.h>
 
 #include "csrc_dipu/runtime/core/DIPUEvent.h"
 
@@ -14,7 +19,7 @@ class AsyncResourcePool {
  public:
   virtual void add(const T& t, std::deque<DIPUEvent>& events) = 0;
   virtual T get() = 0;
-  virtual bool ready() const = 0;
+  virtual bool ready() = 0;
   virtual bool empty() const = 0;
   virtual size_t size() const = 0;
 };
@@ -48,7 +53,7 @@ class AsyncResourcePoolImpl : public AsyncResourcePool<T> {
     return list_.empty();
   }
 
-  bool ready() const override {
+  bool ready() override {
     std::lock_guard<mutex_t> lk(mutex_);
     if (list_.empty()) {
       return false;
@@ -66,6 +71,99 @@ class AsyncResourcePoolImpl : public AsyncResourcePool<T> {
   size_t size() const override {
     std::lock_guard<mutex_t> lk(mutex_);
     return list_.size();
+  }
+};
+
+template <class T, at::DeviceType device_type, int algorithm>
+class AsyncResourceMultiStreamPoolImpl : public AsyncResourcePool<T> {
+ private:
+  struct Resource {
+    const T t;
+    int event_count;
+    const std::deque<DIPUEvent> events;
+
+    Resource(const T& t, int event_count, std::deque<DIPUEvent>& events)
+        : t(t), event_count(event_count), events(std::move(events)) {}
+  };
+  ska::flat_hash_map<c10::StreamId,
+                     std::queue<std::pair<std::shared_ptr<Resource>, int>>>
+      queues;
+
+  std::shared_ptr<Resource> ready_resource;
+
+  using mutex_t = std::mutex;
+  mutable mutex_t mutex;
+
+ public:
+  void add(const T& t, std::deque<DIPUEvent>& events) override {
+    std::lock_guard<mutex_t> lk(mutex);
+    auto resource = std::make_shared<Resource>(t, events.size(), events);
+    if (0 == resource->event_count) {
+      // Special queue for resources that have no events to wait
+      queues[-1].push({resource, -1});
+    } else {
+      for (int i = 0; i < resource->event_count; ++i) {
+        queues[resource->events[i].stream_id()].push({resource, i});
+      }
+    }
+  }
+
+  T get() override {
+    std::lock_guard<mutex_t> lk(mutex);
+    TORCH_CHECK(ready_resource, "No ready resource to get!")
+    T t = ready_resource->t;
+    ready_resource.reset();
+    return t;
+  }
+
+  bool empty() const override {
+    std::lock_guard<mutex_t> lk(mutex);
+    return queues.empty();
+  }
+
+  // Remove completed events in queues and decrease event_count until a resource
+  // with event_count of 0 is found, then save it to ready_resource
+  bool ready() override {
+    std::lock_guard<mutex_t> lk(mutex);
+
+    if (ready_resource) {
+      return true;
+    }
+
+    for (auto it = queues.begin(); it != queues.end();) {
+      auto& [stream_id, queue] = *it;
+      auto& [resource, event_id] = queue.front();
+      if (0 == resource->event_count || resource->events[event_id].query()) {
+        // Skip --event_count for resources in the special queue
+        // since their event_count is already 0
+        if (resource->event_count > 0) {
+          --resource->event_count;
+        }
+        if (0 == resource->event_count) {
+          ready_resource = resource;
+        }
+        queue.pop();
+        if (queue.empty()) {
+          it = queues.erase(it);
+        } else {
+          ++it;
+        }
+        if (ready_resource) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  size_t size() const override {
+    std::lock_guard<mutex_t> lk(mutex);
+    size_t size_sum = 0;
+    for (auto& [stream_id, queue] : queues) {
+      size_sum += queue.size();
+    }
+    return size_sum;
   }
 };
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUAsyncResourcePool.h
@@ -2,7 +2,6 @@
 #pragma once
 
 #include <deque>
-#include <memory>
 #include <mutex>
 #include <queue>
 #include <tuple>

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBFCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBFCachingAllocator.cpp
@@ -611,8 +611,9 @@ static void deleteBFContext(void* ptr) {
 
 // TODO(allocator) - Refactor it!
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
-DIPU_REGISTER_ALLOCATOR(BF, DIPU_DEVICE_TYPE_MACRO, BFCachingAllocator, 1, 0);
-DIPU_REGISTER_ALLOCATOR(BF, CPU, BFCachingAllocator, 1, 0);
+DIPU_REGISTER_ALLOCATOR(BF, DIPU_DEVICE_TYPE_MACRO, BFCachingAllocator,
+                        OneStreamOneQueueAlgo, 0);
+DIPU_REGISTER_ALLOCATOR(BF, CPU, BFCachingAllocator, OneStreamOneQueueAlgo, 0);
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
 
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBFCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBFCachingAllocator.cpp
@@ -611,8 +611,8 @@ static void deleteBFContext(void* ptr) {
 
 // TODO(allocator) - Refactor it!
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
-DIPU_REGISTER_ALLOCATOR(BF, DIPU_DEVICE_TYPE_MACRO, BFCachingAllocator, 0);
-DIPU_REGISTER_ALLOCATOR(BF, CPU, BFCachingAllocator, 0);
+DIPU_REGISTER_ALLOCATOR(BF, DIPU_DEVICE_TYPE_MACRO, BFCachingAllocator, 1, 0);
+DIPU_REGISTER_ALLOCATOR(BF, CPU, BFCachingAllocator, 1, 0);
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
 
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBFCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBFCachingAllocator.cpp
@@ -525,7 +525,6 @@ class BFCachingAllocator : public CacheAllocator {
           allocator_->set_memory_allocated(allocator_->memory_allocated() -
                                            nbytes_);
         }
-        allocator_->restore();
       } else {
         DIPU_DEBUG_ALLOCATOR(8,
                              "BFCachingAllocator:~Context: destory tensor "

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBSCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBSCachingAllocator.cpp
@@ -232,8 +232,9 @@ static void deleteBSContext(void* ptr) {
 
 // TODO(allocator) - Refactor it!
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
-DIPU_REGISTER_ALLOCATOR(BS, DIPU_DEVICE_TYPE_MACRO, BSCachingAllocator, 1, 0);
-DIPU_REGISTER_ALLOCATOR(BS, CPU, BSCachingAllocator, 1, 0);
+DIPU_REGISTER_ALLOCATOR(BS, DIPU_DEVICE_TYPE_MACRO, BSCachingAllocator,
+                        OneStreamOneQueueAlgo, 0);
+DIPU_REGISTER_ALLOCATOR(BS, CPU, BSCachingAllocator, OneStreamOneQueueAlgo, 0);
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
 
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBSCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUBSCachingAllocator.cpp
@@ -232,8 +232,8 @@ static void deleteBSContext(void* ptr) {
 
 // TODO(allocator) - Refactor it!
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
-DIPU_REGISTER_ALLOCATOR(BS, DIPU_DEVICE_TYPE_MACRO, BSCachingAllocator, 0);
-DIPU_REGISTER_ALLOCATOR(BS, CPU, BSCachingAllocator, 0);
+DIPU_REGISTER_ALLOCATOR(BS, DIPU_DEVICE_TYPE_MACRO, BSCachingAllocator, 1, 0);
+DIPU_REGISTER_ALLOCATOR(BS, CPU, BSCachingAllocator, 1, 0);
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
 
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.cpp
@@ -20,7 +20,7 @@ namespace dipu {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::mutex DIPURawDeviceAllocator::mutex_;
 
-constexpr size_t kDefaultMaxAsyncResourcePoolLength = 64;
+constexpr size_t kDefaultMaxAsyncResourcePoolLength = 96;
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 const size_t kMaxAsyncResourcePoolLength = get_env_or_default(
     "DIPU_MAX_ASYNC_RESOURCE_POOL_LENGTH", kDefaultMaxAsyncResourcePoolLength);

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.cpp
@@ -249,19 +249,6 @@ class DIPUDeviceCachingProxy : public c10::Allocator {
   ~DIPUDeviceCachingProxy() override = default;
 
   c10::DataPtr allocate(size_t size) const override {
-    auto currentStream = getCurrentDIPUStream();
-    auto defaultStream = getDefaultDIPUStream();
-    DIPUEvent event;
-    if (currentStream != defaultStream) {
-      // When allocating memory to a non-default stream, since record_stream is
-      // not performed on the default stream, the non-default stream needs to
-      // wait for the operation on the default stream to be completed. After
-      // adding non-default stream and other default stream operations here, the
-      // upper layer does not need to manually add a wait for the default stream
-      // when allocating memory on the non-default stream.
-      event.record(defaultStream);
-      event.wait(currentStream);
-    }
     return getAllocator(device_type_)->allocate(size);
   }
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
@@ -244,18 +244,20 @@ c10::Allocator* get_allocator(int device_id, c10::Allocator* raw_allocator) {
 }
 #undef DIPU_ALLOCATOR_DISPATCH_DEVICE_ID
 
-#define DIPU_REGISTER_ALLOCATOR(name, device_type, CachingAllocator, priority) \
-  namespace name##device_type {                                                \
-    static allocator_details::RawAllocator<at::DeviceType::device_type>::type  \
-        raw_allocator;                                                         \
-    using AsyncMemPool = AsyncResourceMultiStreamPoolImpl<                     \
-        std::tuple<void*, size_t>, at::DeviceType::device_type, priority>;     \
-    static const std::function<c10::Allocator*(int)> allocator_get_fn =        \
-        std::bind(                                                             \
-            allocator_details::get_allocator<CachingAllocator, AsyncMemPool>,  \
-            std::placeholders::_1, &raw_allocator);                            \
-    static const allocator_details::AllocatorRegisterer g_allocator(           \
-        #name, at::DeviceType::device_type, allocator_get_fn, priority);       \
+#define DIPU_REGISTER_ALLOCATOR(name, device_type, CachingAllocator,          \
+                                algorithm, priority)                          \
+  namespace name##device_type {                                               \
+    static allocator_details::RawAllocator<at::DeviceType::device_type>::type \
+        raw_allocator;                                                        \
+    using AsyncMemPool =                                                      \
+        AsyncResourcePoolImpl<std::tuple<void*, size_t>,                      \
+                              at::DeviceType::device_type, algorithm>;        \
+    static const std::function<c10::Allocator*(int)> allocator_get_fn =       \
+        std::bind(                                                            \
+            allocator_details::get_allocator<CachingAllocator, AsyncMemPool>, \
+            std::placeholders::_1, &raw_allocator);                           \
+    static const allocator_details::AllocatorRegisterer g_allocator(          \
+        #name, at::DeviceType::device_type, allocator_get_fn, priority);      \
   }
 }  // namespace allocator_details
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
@@ -248,9 +248,8 @@ c10::Allocator* get_allocator(int device_id, c10::Allocator* raw_allocator) {
   namespace name##device_type {                                                \
     static allocator_details::RawAllocator<at::DeviceType::device_type>::type  \
         raw_allocator;                                                         \
-    using AsyncMemPool =                                                       \
-        AsyncResourceMultiStreamPoolImpl<std::tuple<void*, size_t>,            \
-                              at::DeviceType::device_type, priority>;          \
+    using AsyncMemPool = AsyncResourceMultiStreamPoolImpl<                     \
+        std::tuple<void*, size_t>, at::DeviceType::device_type, priority>;     \
     static const std::function<c10::Allocator*(int)> allocator_get_fn =        \
         std::bind(                                                             \
             allocator_details::get_allocator<CachingAllocator, AsyncMemPool>,  \

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingAllocator.h
@@ -249,7 +249,7 @@ c10::Allocator* get_allocator(int device_id, c10::Allocator* raw_allocator) {
     static allocator_details::RawAllocator<at::DeviceType::device_type>::type  \
         raw_allocator;                                                         \
     using AsyncMemPool =                                                       \
-        AsyncResourcePoolImpl<std::tuple<void*, size_t>,                       \
+        AsyncResourceMultiStreamPoolImpl<std::tuple<void*, size_t>,            \
                               at::DeviceType::device_type, priority>;          \
     static const std::function<c10::Allocator*(int)> allocator_get_fn =        \
         std::bind(                                                             \

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPURawCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPURawCachingAllocator.cpp
@@ -40,8 +40,8 @@ class RawCachingAllocator : public CacheAllocator {
     size_t nbytes = getAllocateSize(size);
     empty_cache();
     DIPU_DEBUG_ALLOCATOR(4, "RawCachingAllocator: malloc "
-                                << nbytes << " nbytes" << ", requires:" << size
-                                << " bytes");
+                                << nbytes << " nbytes"
+                                << ", requires:" << size << " bytes");
     auto ptr = raw_allocator()->raw_allocate(nbytes);
     set_memory_reserved(memory_reserved() + nbytes);
     set_memory_allocated(memory_allocated() + nbytes);

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPURawCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPURawCachingAllocator.cpp
@@ -40,8 +40,8 @@ class RawCachingAllocator : public CacheAllocator {
     size_t nbytes = getAllocateSize(size);
     empty_cache();
     DIPU_DEBUG_ALLOCATOR(4, "RawCachingAllocator: malloc "
-                                << nbytes << " nbytes"
-                                << ", requires:" << size << " bytes");
+                                << nbytes << " nbytes" << ", requires:" << size
+                                << " bytes");
     auto ptr = raw_allocator()->raw_allocate(nbytes);
     set_memory_reserved(memory_reserved() + nbytes);
     set_memory_allocated(memory_allocated() + nbytes);
@@ -77,8 +77,8 @@ static void deleteRawCachingAllocatorContext(void* ptr) {
 }
 // TODO(allocator) - Refactor it!
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
-DIPU_REGISTER_ALLOCATOR(RAW, DIPU_DEVICE_TYPE_MACRO, RawCachingAllocator, 0);
-DIPU_REGISTER_ALLOCATOR(RAW, CPU, RawCachingAllocator, 0);
+DIPU_REGISTER_ALLOCATOR(RAW, DIPU_DEVICE_TYPE_MACRO, RawCachingAllocator, 1, 0);
+DIPU_REGISTER_ALLOCATOR(RAW, CPU, RawCachingAllocator, 1, 0);
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
 
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPURawCachingAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPURawCachingAllocator.cpp
@@ -77,8 +77,10 @@ static void deleteRawCachingAllocatorContext(void* ptr) {
 }
 // TODO(allocator) - Refactor it!
 // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
-DIPU_REGISTER_ALLOCATOR(RAW, DIPU_DEVICE_TYPE_MACRO, RawCachingAllocator, 1, 0);
-DIPU_REGISTER_ALLOCATOR(RAW, CPU, RawCachingAllocator, 1, 0);
+DIPU_REGISTER_ALLOCATOR(RAW, DIPU_DEVICE_TYPE_MACRO, RawCachingAllocator,
+                        OneStreamOneQueueAlgo, 0);
+DIPU_REGISTER_ALLOCATOR(RAW, CPU, RawCachingAllocator, OneStreamOneQueueAlgo,
+                        0);
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables,modernize-avoid-bind)
 
 }  // namespace dipu


### PR DESCRIPTION
- Implement a partial template specialization for AsyncResourcePoolImpl (algorithm = OneStreamOneQueueAlgo = 1) as a new implementation which provides a separate queue for each stream in the asynchronous resource pool. According to https://github.com/pytorch/pytorch/blob/03a05e791aabe4f2e3938626bff849641dc101ea/c10/cuda/CUDACachingAllocator.cpp#L2745 this implementation can avoid head-of-line delays if one or more streams has long-running operations to wait for.
  - Use the new implementation in BF, BS, RAW caching allocators to replace the old implementation, which has one global queue for all streams.
  - Compared to the old implementation where any event won't be returned to the event pool until all events attached to the same resource are complete, another advantage of the new implementation is that as long as one event is complete, it will be returned to the event pool immediately.
- Remove the restore operation in tensor destruction.
- Remove useless legacy code in DIPUCachingAllocator.cpp
- Fix DIPUEvent's move constructor and move assignment operator by setting `event_` to nullptr inside. If we don't do this, when the original DIPUEvent object (A) is destructed after being moved to a new object (B), the device event `event_` that is still being used by B will be returned to the EventPool, and may be reused in the future while B has no idea about it.

When testing the Llama-2-70B sft task on 64 accelerator cards with tp8 + pp8, which essentially requires two streams (default + communication), compared to old implementation, no performance degradation is observed for this new implementation.