### PR TITLE
[DIPU] Fix custom fallback for non-out ops of silu, rsqrt which lacks postprocessing conversion for out tensor

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/aten/ops/CustomFallbackFunctions.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/CustomFallbackFunctions.hpp
@@ -44,7 +44,7 @@ static at::Tensor& custom_fallback_dipu_silu_out(const at::Tensor& self,
 static at::Tensor custom_fallback_dipu_silu(const at::Tensor& self) {
   DIPU_OP_LOG_WARNING_ONCE("custom fallback to cpu, name=silu" << std::endl);
   auto self_cpu = to_cpu_with_half_to_float(self);
-  return at::silu(self_cpu);
+  return at::silu(self_cpu).to(self.options());
 }
 
 static c10::List<c10::optional<at::Tensor>> to_cpu(
@@ -460,7 +460,7 @@ static at::Tensor& custom_fallback_dipu_rsqrt_out(const at::Tensor& self,
 
 static at::Tensor custom_fallback_dipu_rsqrt(const at::Tensor& self) {
   auto self_cpu = to_cpu_with_half_to_float(self);
-  return at::rsqrt(self_cpu);
+  return at::rsqrt(self_cpu).to(self.options());
 }
 
 static at::Tensor& custom_fallback_dipu__softmax_out(const at::Tensor& self,


### PR DESCRIPTION
As titled