### PR TITLE
refactor(dipu): redesign environ.hpp to be a better code base

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/base/environ.hpp
+++ b/dipu/torch_dipu/csrc_dipu/base/environ.hpp
@@ -6,9 +6,44 @@
 
 #pragma once
 
-#include <charconv>
 #include <cstdlib>
 #include <string_view>
+
+// FIXME: DIPU is expected to be built with a compiler that supports C++17.
+//        This is a temporary fix for older compilers that don't have
+//        <charconv>. (e.g., GCC 7.5 in Acsend toolchain)
+#if __has_include(<charconv>)
+#include <charconv>
+#else
+#include <stdexcept>
+#include <string>
+#include <system_error>
+namespace std {
+// HACK: Define a subset of std::from_chars for compilers that don't support.
+namespace my_from_chars {
+struct from_chars_result {
+  const char* ptr;
+  std::errc ec;
+};
+inline from_chars_result from_chars(const char* first, const char* last,
+                                    int& value, int base = 10) {  // NOLINT
+  std::size_t pos{};
+  std::errc ec{};
+  try {
+    value = std::stoi(std::string(first, last), &pos, base);
+  } catch (const std::invalid_argument&) {
+    ec = std::errc::invalid_argument;
+  } catch (const std::out_of_range&) {
+    // WARNING: pos is 0 in this case, which is not aligned with the standard.
+    ec = std::errc::result_out_of_range;
+  }
+  return {first + pos, ec};
+}
+}  // namespace my_from_chars
+using my_from_chars::from_chars;
+using my_from_chars::from_chars_result;
+}  // namespace std
+#endif
 
 namespace dipu::environ {
 
@@ -22,7 +57,8 @@ inline std::string_view getEnvOrEmpty(const char* env_var) {
 inline int getEnvIntOrDefault(const char* env_var, int default_value = 0) {
   int value = default_value;
   auto env = getEnvOrEmpty(env_var);
-  std::from_chars(env.begin(), env.end(), value);
+  std::from_chars(env.data(), env.data() + env.size(), value);
+  // TODO(lilingjie): maybe add warning here if conversion fails.
   return value;
 }
 

--- a/dipu/torch_dipu/csrc_dipu/base/environ.hpp
+++ b/dipu/torch_dipu/csrc_dipu/base/environ.hpp
@@ -6,74 +6,86 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
 #include <cstdlib>
-#include <string_view>
-
-// FIXME: DIPU is expected to be built with a compiler that supports C++17.
-//        This is a temporary fix for older compilers that don't have
-//        <charconv>. (e.g., GCC 7.5 in Acsend toolchain)
-#if __has_include(<charconv>)
-#include <charconv>
-#else
-#include <stdexcept>
+#include <sstream>
 #include <string>
-#include <system_error>
-namespace std {
-// HACK: Define a subset of std::from_chars for compilers that don't support.
-namespace my_from_chars {
-struct from_chars_result {
-  const char* ptr;
-  std::errc ec;
-};
-inline from_chars_result from_chars(const char* first, const char* last,
-                                    int& value, int base = 10) {  // NOLINT
-  std::size_t pos{};
-  std::errc ec{};
-  try {
-    value = std::stoi(std::string(first, last), &pos, base);
-  } catch (const std::invalid_argument&) {
-    ec = std::errc::invalid_argument;
-  } catch (const std::out_of_range&) {
-    // WARNING: pos is 0 in this case, which is not aligned with the standard.
-    ec = std::errc::result_out_of_range;
-  }
-  return {first + pos, ec};
-}
-}  // namespace my_from_chars
-using my_from_chars::from_chars;
-using my_from_chars::from_chars_result;
-}  // namespace std
-#endif
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+#include "csrc_dipu/runtime/device/basedef.h"
 
 namespace dipu::environ {
 
 namespace detail {
 
-inline std::string_view getEnvOrEmpty(const char* env_var) {
-  const char* env = std::getenv(env_var);
-  return env ? env : "";
-}
-
-inline int getEnvIntOrDefault(const char* env_var, int default_value = 0) {
-  int value = default_value;
-  auto env = getEnvOrEmpty(env_var);
-  std::from_chars(env.data(), env.data() + env.size(), value);
-  // TODO(lilingjie): maybe add warning here if conversion fails.
-  return value;
-}
-
-inline bool getEnvFlag(const char* env_var) {
-  return getEnvIntOrDefault(env_var, 0) > 0;
+template <typename T, typename U>
+T getEnvOrDefault(const char* env_var, U&& default_value,
+                  const char* type_name = typeid(T).name()) {
+  // PERF: not considering performance here as this is only used on startup
+  //       and not using <charconv> for backward-compatibility
+  static_assert(std::is_convertible_v<U, T>);
+  static_assert(!std::is_pointer_v<T> && !std::is_reference_v<T>);
+  const char* env_cstr = std::getenv(env_var);
+  if (!env_cstr) {
+    return std::forward<U>(default_value);
+  }
+  if constexpr (std::is_same_v<T, std::string>) {
+    return env_cstr;
+  } else if constexpr (std::is_same_v<T, bool>) {
+    // CMake-like boolean values
+    std::string env_str(env_cstr);
+    std::transform(env_str.begin(), env_str.end(), env_str.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (env_str == "1" || env_str == "true" || env_str == "on" ||
+        env_str == "yes" || env_str == "y") {
+      return true;
+    }
+    if (env_str == "0" || env_str == "false" || env_str == "off" ||
+        env_str == "no" || env_str == "n") {
+      return false;
+    }
+    return getEnvOrDefault<std::int64_t>(env_var, default_value, type_name);
+  } else {
+    std::istringstream env_ss(env_cstr);
+    T value{};
+    env_ss >> value;
+    if (env_ss.fail()) {
+      DIPU_LOGE(
+          "Failed to parse env var %s='%s' as type '%s', using default value "
+          "'%s'.",
+          env_var, env_cstr, type_name, std::to_string(default_value).c_str());
+      return std::forward<U>(default_value);
+    }
+    if (!env_ss.eof()) {
+      DIPU_LOGW(
+          "Only parsed %s out of %zu characters from env var %s='%s' as type "
+          "'%s', using value '%s'.",
+          std::to_string(env_ss.tellg()).c_str(), env_ss.str().size(), env_var,
+          env_cstr, type_name, std::to_string(value).c_str());
+    }
+    return value;
+  }
 }
 
 }  // namespace detail
 
+#ifdef DIPU_ENV_VAR
+#error "DIPU_ENV_VAR already defined."
+#endif
+#define DIPU_ENV_VAR(ACCESSOR, NAME, TYPE, DEFAULT)                          \
+  inline const auto& ACCESSOR() {                                            \
+    static auto value = detail::getEnvOrDefault<TYPE>(NAME, DEFAULT, #TYPE); \
+    return value;                                                            \
+  }
+
 // Determine whether DipuOpRegister should register ops immediately in
 // registerOpMaybeDelayed(), or delay the registration of ops until
 // applyDelayedRegister() is called.
-inline bool immediateRegisterOp() {
-  static bool flag = detail::getEnvFlag("DIPU_IMMEDIATE_REGISTER_OP");
-  return flag;
-}
+DIPU_ENV_VAR(immediateRegisterOp, "DIPU_IMMEDIATE_REGISTER_OP", bool, false);
+
+#undef DIPU_ENV_VAR
 
 }  // namespace dipu::environ

--- a/dipu/torch_dipu/csrc_dipu/runtime/device/basedef.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/device/basedef.h
@@ -23,11 +23,11 @@ using enum_t = int32_t;
 #define DIPU_CODELOC __FILE__ " (" DIPU_STRING(__LINE__) ")"
 
 #define DIPU_LOGE(fmt, ...)                                              \
-  printf("[ERROR]%s,%s:%u:" #fmt "\n", __FUNCTION__, __FILE__, __LINE__, \
+  printf("[ERROR]%s:%u:%s: " fmt "\n", __FILE__, __LINE__, __FUNCTION__, \
          ##__VA_ARGS__)
 
 #define DIPU_LOGW(fmt, ...)                                             \
-  printf("[WARN]%s,%s:%u:" #fmt "\n", __FUNCTION__, __FILE__, __LINE__, \
+  printf("[WARN]%s:%u:%s: " fmt "\n", __FILE__, __LINE__, __FUNCTION__, \
          ##__VA_ARGS__)
 
 namespace devapis {


### PR DESCRIPTION
gcc 7.5 对 c++17 支持不完整，暂且加了一个绕过。

**Update**：干脆直接重写了