### PR TITLE
[dipu] feat: add gather and scatter support by using recv and send

### DIFF
--- a/dipu/tests/python/individual_scripts/test_rt_ddp.py
+++ b/dipu/tests/python/individual_scripts/test_rt_ddp.py
@@ -233,7 +233,6 @@ def demo_gather(rank, world_size, port):
 
     setup(rank, world_size, port)
 
-
     root_rank = 0
     src = torch.ones((2, 4)).to(rank) * (rank + 1)
     if rank == root_rank:
@@ -258,7 +257,9 @@ def demo_scatter(rank, world_size, port):
     root_rank = 0
     dst = torch.empty((2, 4)).to(rank)
     if rank == root_rank:
-        scatter_list = [torch.ones((2, 4)).to(rank) * (i + 1) for i in range(world_size)]
+        scatter_list = [
+            torch.ones((2, 4)).to(rank) * (i + 1) for i in range(world_size)
+        ]
     else:
         scatter_list = None
     for i in range(1, 3):

--- a/dipu/tests/python/individual_scripts/test_rt_ddp.py
+++ b/dipu/tests/python/individual_scripts/test_rt_ddp.py
@@ -226,6 +226,47 @@ def demo_bcast(rank, world_size, port):
     cleanup()
 
 
+def demo_gather(rank, world_size, port):
+    import torch_dipu
+
+    torch.cuda.set_device(rank)
+
+    setup(rank, world_size, port)
+
+
+    root_rank = 0
+    src = torch.ones((2, 4)).to(rank) * (rank + 1)
+    if rank == root_rank:
+        gather_list = [torch.empty((2, 4)).to(rank) for _ in range(world_size)]
+    else:
+        gather_list = None
+    for i in range(1, 3):
+        dist.gather(src, gather_list, dst=root_rank)
+    if rank == root_rank:
+        for i in range(world_size):
+            assert torch.allclose(torch.ones((2, 4)) * (i + 1), gather_list[i].cpu())
+    cleanup()
+
+
+def demo_scatter(rank, world_size, port):
+    import torch_dipu
+
+    torch.cuda.set_device(rank)
+
+    setup(rank, world_size, port)
+
+    root_rank = 0
+    dst = torch.empty((2, 4)).to(rank)
+    if rank == root_rank:
+        scatter_list = [torch.ones((2, 4)).to(rank) * (i + 1) for i in range(world_size)]
+    else:
+        scatter_list = None
+    for i in range(1, 3):
+        dist.scatter(dst, scatter_list, src=root_rank)
+    assert torch.allclose(torch.ones((2, 4)) * (rank + 1), dst.cpu())
+    cleanup()
+
+
 def demo_reduce(rank, world_size, port):
     import torch_dipu
 
@@ -411,6 +452,8 @@ if __name__ == "__main__":
     run_demo(demo_reduce, world_size, port)
     run_demo(demo_reducescatter, world_size, port)
     run_demo(demo_reducescatter_base, world_size, port)
+    run_demo(demo_gather, world_size, port)
+    run_demo(demo_scatter, world_size, port)
 
     run_demo(demo_allgather_gloo, world_size, port)
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
@@ -47,7 +47,7 @@ devapis::diclResult_t diclAllGather(const void* sendbuff, void* recvbuff,
                                 stream);
 }
 
-// for non-root rank, we suggested to pass nullptr to recvbuf
+// for non-root rank, we suggest to pass nullptr to recvbuf
 devapis::diclResult_t diclGather(void* sendbuf, void* const* recvbuf,
                                  size_t count, at::ScalarType datatype,
                                  int root, int curRank, int numRanks,
@@ -71,7 +71,7 @@ devapis::diclResult_t diclGather(void* sendbuf, void* const* recvbuf,
   return devapis::diclResult_t::DICL_SUCCESS;
 }
 
-// for non-root rank, we suggested to pass nullptr to sendbuf
+// for non-root rank, we suggest to pass nullptr to sendbuf
 devapis::diclResult_t diclScatter(void* const* sendbuf, void* recvbuf,
                                   size_t count, at::ScalarType datatype,
                                   int root, int curRank, int numRanks,

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
@@ -60,9 +60,8 @@ devapis::diclResult_t diclGather(void* sendbuf, void* const* recvbuf,
     if (srcRank == root) {
       continue;
     }
-    auto recvbufForSrcRank = recvbuf[srcRank];
     DIPU_CALL_DICLAPIS(
-        diclRecv(recvbufForSrcRank, count, datatype, srcRank, comm, stream));
+        diclRecv(recvbuf[srcRank], count, datatype, srcRank, comm, stream));
   }
 
   auto deviceId = static_cast<devapis::deviceId_t>(curRank);
@@ -84,9 +83,8 @@ devapis::diclResult_t diclScatter(void* const* sendbuf, void* recvbuf,
     if (dstRank == root) {
       continue;
     }
-    auto sendbufForDstRank = sendbuf[dstRank];
     DIPU_CALL_DICLAPIS(
-        diclSend(sendbufForDstRank, count, datatype, dstRank, comm, stream));
+        diclSend(sendbuf[dstRank], count, datatype, dstRank, comm, stream));
   }
 
   auto deviceId = static_cast<devapis::deviceId_t>(curRank);

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
@@ -47,20 +47,20 @@ devapis::diclResult_t diclAllGather(const void* sendbuff, void* recvbuff,
                                 stream);
 }
 
-devapis::diclResult_t diclGather(void* sendbuff, void** recvbuff,
-                                 size_t count, at::ScalarType datatype,
-                                 int root, int curRank, int numRanks,
-                                 size_t inputDataBytes, diclComm_t comm,
-                                 deviceStream_t stream) {
+devapis::diclResult_t diclGather(void* sendbuff, void** recvbuff, size_t count,
+                                 at::ScalarType datatype, int root, int curRank,
+                                 int numRanks, size_t inputDataBytes,
+                                 diclComm_t comm, deviceStream_t stream) {
   if (curRank == root) {
     for (const auto r : c10::irange(numRanks)) {
-      auto recvbuffForRank = *(recvbuff+r);
+      auto recvbuffForRank = *(recvbuff + r);
       if (r != root) {
-        DIPU_CALL_DICLAPIS(diclRecv(recvbuffForRank, count, datatype, r, comm, stream));
+        DIPU_CALL_DICLAPIS(
+            diclRecv(recvbuffForRank, count, datatype, r, comm, stream));
       } else {
         auto deviceId = static_cast<devapis::deviceId_t>(curRank);
-        devapis::memCopyD2DAsync(stream, inputDataBytes, deviceId, recvbuffForRank,
-                                 deviceId, sendbuff);
+        devapis::memCopyD2DAsync(stream, inputDataBytes, deviceId,
+                                 recvbuffForRank, deviceId, sendbuff);
       }
     }
   } else {
@@ -69,16 +69,17 @@ devapis::diclResult_t diclGather(void* sendbuff, void** recvbuff,
   return devapis::diclResult_t::DICL_SUCCESS;
 }
 
-devapis::diclResult_t diclScatter(void** sendbuff, void* recvbuff,
-                                  size_t count, at::ScalarType datatype,
-                                  int root, int curRank, int numRanks,
+devapis::diclResult_t diclScatter(void** sendbuff, void* recvbuff, size_t count,
+                                  at::ScalarType datatype, int root,
+                                  int curRank, int numRanks,
                                   size_t outputDataBytes, diclComm_t comm,
                                   deviceStream_t stream) {
   if (curRank == root) {
     for (const auto r : c10::irange(numRanks)) {
-      auto sendbuffForRank = *(sendbuff+r);
+      auto sendbuffForRank = *(sendbuff + r);
       if (r != root) {
-        DIPU_CALL_DICLAPIS(diclSend(sendbuffForRank, count, datatype, r, comm, stream));
+        DIPU_CALL_DICLAPIS(
+            diclSend(sendbuffForRank, count, datatype, r, comm, stream));
       } else {
         auto deviceId = static_cast<devapis::deviceId_t>(curRank);
         devapis::memCopyD2DAsync(stream, outputDataBytes, deviceId, recvbuff,

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
@@ -41,12 +41,14 @@ DIPU_API devapis::diclResult_t diclAllGather(const void* sendbuff,
                                              diclComm_t comm,
                                              deviceStream_t stream);
 
+// for non-root rank, we suggest passing nullptr as recvbuf
 DIPU_API devapis::diclResult_t diclGather(void* sendbuf, void* const* recvbuf,
                                           size_t count, at::ScalarType datatype,
                                           int root, int curRank, int numRanks,
                                           diclComm_t comm,
                                           deviceStream_t stream);
 
+// for non-root rank, we suggest passing nullptr as sendbuf
 DIPU_API devapis::diclResult_t diclScatter(void* const* sendbuf, void* recvbuf,
                                            size_t count,
                                            at::ScalarType datatype, int root,

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
@@ -41,13 +41,13 @@ DIPU_API devapis::diclResult_t diclAllGather(const void* sendbuff,
                                              diclComm_t comm,
                                              deviceStream_t stream);
 
-DIPU_API devapis::diclResult_t diclGather(void* sendbuff, void** recvbuff,
+DIPU_API devapis::diclResult_t diclGather(void* sendbuf, void* const* recvbuf,
                                           size_t count, at::ScalarType datatype,
                                           int root, int curRank, int numRanks,
                                           diclComm_t comm,
                                           deviceStream_t stream);
 
-DIPU_API devapis::diclResult_t diclScatter(void** sendbuff, void* recvbuff,
+DIPU_API devapis::diclResult_t diclScatter(void* const* sendbuf, void* recvbuf,
                                            size_t count,
                                            at::ScalarType datatype, int root,
                                            int curRank, int numRanks,

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
@@ -44,14 +44,15 @@ DIPU_API devapis::diclResult_t diclAllGather(const void* sendbuff,
 DIPU_API devapis::diclResult_t diclGather(void* sendbuff, void** recvbuff,
                                           size_t count, at::ScalarType datatype,
                                           int root, int curRank, int numRanks,
-                                          size_t inputDataBytes,
                                           diclComm_t comm,
                                           deviceStream_t stream);
 
-DIPU_API devapis::diclResult_t diclScatter(
-    void** sendbuff, void* recvbuff, size_t count, at::ScalarType datatype,
-    int root, int curRank, int numRanks, size_t outputDataBytes,
-    diclComm_t comm, deviceStream_t stream);
+DIPU_API devapis::diclResult_t diclScatter(void** sendbuff, void* recvbuff,
+                                           size_t count,
+                                           at::ScalarType datatype, int root,
+                                           int curRank, int numRanks,
+                                           diclComm_t comm,
+                                           deviceStream_t stream);
 
 DIPU_API devapis::diclResult_t diclReduce(const void* sendbuff, void* recvbuff,
                                           size_t count, at::ScalarType datatype,

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
@@ -4,6 +4,14 @@
 #include "csrc_dipu/runtime/device/diclapis.h"
 
 namespace dipu {
+
+#define DIPU_CALL_DICLAPIS(Expr)                                           \
+  {                                                                        \
+    devapis::diclResult_t ret = Expr;                                      \
+    TORCH_CHECK(ret == devapis::diclResult_t::DICL_SUCCESS,                \
+                "call diclapis error, expr = ", #Expr, ", ret = ", ret)    \
+  }
+
 // need enhance return status.
 namespace devproxy {
 
@@ -32,6 +40,18 @@ DIPU_API devapis::diclResult_t diclAllGather(const void* sendbuff,
                                              at::ScalarType datatype,
                                              diclComm_t comm,
                                              deviceStream_t stream);
+
+DIPU_API devapis::diclResult_t diclGather(void* sendbuff, void** recvbuff,
+                                          size_t count, at::ScalarType datatype,
+                                          int root, int curRank, int numRanks,
+                                          size_t inputDataBytes, diclComm_t comm,
+                                          deviceStream_t stream);
+
+DIPU_API devapis::diclResult_t diclScatter(void** sendbuff, void* recvbuff,
+                                           size_t count, at::ScalarType datatype,
+                                           int root, int curRank, int numRanks,
+                                           size_t outputDataBytes, diclComm_t comm,
+                                           deviceStream_t stream);
 
 DIPU_API devapis::diclResult_t diclReduce(const void* sendbuff, void* recvbuff,
                                           size_t count, at::ScalarType datatype,

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
@@ -5,11 +5,11 @@
 
 namespace dipu {
 
-#define DIPU_CALL_DICLAPIS(Expr)                                           \
-  {                                                                        \
-    devapis::diclResult_t ret = Expr;                                      \
-    TORCH_CHECK(ret == devapis::diclResult_t::DICL_SUCCESS,                \
-                "call diclapis error, expr = ", #Expr, ", ret = ", ret)    \
+#define DIPU_CALL_DICLAPIS(Expr)                                        \
+  {                                                                     \
+    devapis::diclResult_t ret = Expr;                                   \
+    TORCH_CHECK(ret == devapis::diclResult_t::DICL_SUCCESS,             \
+                "call diclapis error, expr = ", #Expr, ", ret = ", ret) \
   }
 
 // need enhance return status.
@@ -44,14 +44,14 @@ DIPU_API devapis::diclResult_t diclAllGather(const void* sendbuff,
 DIPU_API devapis::diclResult_t diclGather(void* sendbuff, void** recvbuff,
                                           size_t count, at::ScalarType datatype,
                                           int root, int curRank, int numRanks,
-                                          size_t inputDataBytes, diclComm_t comm,
+                                          size_t inputDataBytes,
+                                          diclComm_t comm,
                                           deviceStream_t stream);
 
-DIPU_API devapis::diclResult_t diclScatter(void** sendbuff, void* recvbuff,
-                                           size_t count, at::ScalarType datatype,
-                                           int root, int curRank, int numRanks,
-                                           size_t outputDataBytes, diclComm_t comm,
-                                           deviceStream_t stream);
+DIPU_API devapis::diclResult_t diclScatter(
+    void** sendbuff, void* recvbuff, size_t count, at::ScalarType datatype,
+    int root, int curRank, int numRanks, size_t outputDataBytes,
+    diclComm_t comm, deviceStream_t stream);
 
 DIPU_API devapis::diclResult_t diclReduce(const void* sendbuff, void* recvbuff,
                                           size_t count, at::ScalarType datatype,

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -762,14 +762,13 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::scatter(
   int numRanks = getSize();
   int curRank = getRank();
   int root = static_cast<int>(opts.rootRank);
-  c10d::assertRootRank(invalid_arg_func, static_cast<int>(opts.rootRank),
-                       numRanks);
+  c10d::assertRootRank(invalid_arg_func, root, numRanks);
   checkDeviceTensors(outputs);
   c10d::assertSingleElementOutput(invalid_arg_func, outputs);
   auto output = outputs.back();
   std::vector<at::Tensor> inputTensors;
 
-  if (curRank == opts.rootRank) {
+  if (curRank == root) {
     checkGatherScatterRootRank(inputs, output, numRanks, invalid_arg_func);
     inputTensors = inputs[0];
   } else {

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -101,9 +101,9 @@ void checkGatherScatterRootRank(
   c10d::assertTypeAndSizesMatch(invalid_arg_func, tensors[0], options, sizes);
 }
 
-void combineTenorsPtrRecordStream(std::vector<at::Tensor>& tensors,
-                                  std::vector<void*>& ptr_vec,
-                                  DIPUStream& stream) {
+void combineTensorsPtrRecordStream(std::vector<at::Tensor>& tensors,
+                                   std::vector<void*>& ptr_vec,
+                                   DIPUStream& stream) {
   for (auto& tensor : tensors) {
     ptr_vec.push_back(tensor.data_ptr());
     dipu::recordStream(tensor, stream);
@@ -627,7 +627,7 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::gather(
           DIPUStream& stream) {
         std::vector<void*> output_ptr_vec = {};
         if (curRank == root) {
-          combineTenorsPtrRecordStream(outputTensors, output_ptr_vec, stream);
+          combineTensorsPtrRecordStream(outputTensors, output_ptr_vec, stream);
         }
 
         RECORD_FUNCTION("DiclGather", std::vector<c10::IValue>({input}));
@@ -785,7 +785,7 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::scatter(
           DIPUStream& stream) {
         std::vector<void*> input_ptr_vec = {};
         if (curRank == root) {
-          combineTenorsPtrRecordStream(inputTensors, input_ptr_vec, stream);
+          combineTensorsPtrRecordStream(inputTensors, input_ptr_vec, stream);
         }
 
         RECORD_FUNCTION(

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -89,7 +89,8 @@ void checkGatherScatterRootRank(
     ss << "requires a single-element list containing a list with " << numRanks
        << " tensors.";
     raise_invalid_arg_func(ss.str());
-  } else if (tensors[0].size() != static_cast<size_t>(numRanks)) {
+  }
+  if (tensors[0].size() != static_cast<size_t>(numRanks)) {
     std::stringstream ss;
     ss << "incorrect list size " << tensors[0].size()
        << ". The list size should be " << numRanks

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -3,7 +3,6 @@
 
 #include <utility>
 
-#include <ATen/core/TensorBody.h>
 #include <ATen/record_function.h>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 #include <torch/torch.h>

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -3,6 +3,7 @@
 
 #include <utility>
 
+#include <ATen/core/TensorBody.h>
 #include <ATen/record_function.h>
 #include <torch/csrc/distributed/c10d/Utils.hpp>
 #include <torch/torch.h>
@@ -68,6 +69,45 @@ std::vector<at::Device> getDeviceList(const std::vector<at::Tensor>& tensors) {
 void syncStreams(std::vector<std::shared_ptr<DICLComm>>& comms) {
   for (auto& comm : comms) {
     comm->preSyncStream();
+  }
+}
+
+std::function<void(const std::string&)> getInvalidArgumentFunc(
+    const std::string& prefix) {
+  return [&](const std::string& msg) { TORCH_CHECK(false, prefix + msg) };
+}
+
+// Check function for root rank in scatter and gather op:
+// We assume that tensors has only one element and tensors[0] has numRanks
+// elements. Dtype and shape of elements in tensors[0] should be the same as
+// other.
+void checkGatherScatterRootRank(
+    std::vector<std::vector<at::Tensor>>& tensors, at::Tensor& other,
+    int numRanks, std::function<void(const std::string&)>& invalid_arg_func) {
+  if (tensors.size() != 1) {
+    std::stringstream ss;
+    ss << "requires a single-element list containing a list with " << numRanks
+       << " tensors.";
+    invalid_arg_func(ss.str());
+  } else if (tensors[0].size() != static_cast<size_t>(numRanks)) {
+    std::stringstream ss;
+    ss << "incorrect list size " << tensors[0].size()
+       << ". The list size should be " << numRanks
+       << ", same as size of the process group.";
+    invalid_arg_func(ss.str());
+  }
+
+  const auto& options = other.options();
+  const auto& sizes = other.sizes();
+  c10d::assertTypeAndSizesMatch(invalid_arg_func, tensors[0], options, sizes);
+}
+
+void combineTenorsPtrRecordStream(std::vector<at::Tensor>& tensors,
+                                  std::vector<void*>& ptr_vec,
+                                  DIPUStream& stream) {
+  for (auto& tensor : tensors) {
+    ptr_vec.push_back(tensor.data_ptr());
+    dipu::recordStream(tensor, stream);
   }
 }
 
@@ -559,39 +599,24 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::reduce(
 c10::intrusive_ptr<Work> ProcessGroupDICL::gather(
     std::vector<std::vector<at::Tensor>>& outputs,
     std::vector<at::Tensor>& inputs, const GatherOptions& opts) {
-  static auto invalidArgument = [](const std::string& msg) {
-    TORCH_CHECK(false, "ProcessGroupDICL::gather: " + msg);
-  };
+  // output = input * ranks, no inplace, input = output[rank]
+  std::string prefix = "ProcessGroupDICL::gather: ";
+  static auto invalid_arg_func = getInvalidArgumentFunc(prefix);
   int numRanks = getSize();
   int curRank = getRank();
-  c10d::assertRootRank(invalidArgument, static_cast<int>(opts.rootRank),
-                       numRanks);
+  int root = static_cast<int>(opts.rootRank);
+  c10d::assertRootRank(invalid_arg_func, root, numRanks);
   checkDeviceTensors(inputs);
-  c10d::assertSingleElementOutput(invalidArgument, inputs);
+  c10d::assertSingleElementInput(invalid_arg_func, inputs);
   auto input = inputs.back();
   std::vector<at::Tensor> outputTensors;
 
-  if (curRank == opts.rootRank) {
-    if (outputs.size() != 1) {
-      std::stringstream ss;
-      ss << "requires a single-element output list containing a list with "
-         << numRanks << " tensors.";
-      invalidArgument(ss.str());
-    } else if (outputs[0].size() != static_cast<size_t>(numRanks)) {
-      std::stringstream ss;
-      ss << "Incorrect output list size " << outputs[0].size()
-         << ". Output list size should be " << numRanks
-         << ", same as size of the process group.";
-      invalidArgument(ss.str());
-    }
-
-    const auto& options = input.options();
-    const auto& sizes = input.sizes();
-    c10d::assertTypeAndSizesMatch(invalidArgument, outputs[0], options, sizes);
+  if (curRank == root) {
+    checkGatherScatterRootRank(outputs, input, numRanks, invalid_arg_func);
     outputTensors = outputs[0];
   } else {
     if (!outputs.empty()) {
-      invalidArgument("requires empty output on non-root");
+      invalid_arg_func("requires empty output on non-root");
     }
     outputTensors = {};
     outputTensors.emplace_back();
@@ -601,28 +626,19 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::gather(
       inputs, outputTensors,
       [&](at::Tensor& /* unused */, at::Tensor& /* unused */, diclComm_t comm,
           DIPUStream& stream) {
-        const auto root = static_cast<int>(opts.rootRank);
-        void** gather_output_ptr = nullptr;
-        std::vector<void*> root_output_ptr_vec;
-        size_t inputDataBytes =
-            input.unsafeGetTensorImpl()->unsafe_storage().nbytes();
-
+        std::vector<void*> output_ptr_vec = {};
         if (curRank == root) {
-          root_output_ptr_vec = {};
-          for (auto& outputTensor : outputTensors) {
-            root_output_ptr_vec.push_back(outputTensor.data_ptr());
-            dipu::recordStream(outputTensor, stream);
-          }
-          gather_output_ptr = root_output_ptr_vec.data();
+          combineTenorsPtrRecordStream(outputTensors, output_ptr_vec, stream);
         }
 
         RECORD_FUNCTION("DiclGather", std::vector<c10::IValue>({input}));
         profile::RecordBlockCreator _("DiclGather", stream.rawstream(),
                                       static_cast<int>(stream.id()));
         return devproxy::diclGather(
-            input.data_ptr(), gather_output_ptr,
+            input.data_ptr(),
+            output_ptr_vec.empty() ? nullptr : output_ptr_vec.data(),
             static_cast<size_t>(input.numel()), input.scalar_type(), root,
-            curRank, numRanks, inputDataBytes, comm, stream.rawstream());
+            curRank, numRanks, comm, stream.rawstream());
       },
       OpType::GATHER);
 }
@@ -741,39 +757,24 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::scatter(
     std::vector<at::Tensor>& outputs,
     std::vector<std::vector<at::Tensor>>& inputs, const ScatterOptions& opts) {
   // input = output * ranks, no inplace, output = input[rank]
-  static auto invalidArgument = [](const std::string& msg) {
-    TORCH_CHECK(false, "ProcessGroupDICL::scatter: " + msg);
-  };
+  std::string prefix = "ProcessGroupDICL::scatter: ";
+  static auto invalid_arg_func = getInvalidArgumentFunc(prefix);
   int numRanks = getSize();
   int curRank = getRank();
-  c10d::assertRootRank(invalidArgument, static_cast<int>(opts.rootRank),
+  int root = static_cast<int>(opts.rootRank);
+  c10d::assertRootRank(invalid_arg_func, static_cast<int>(opts.rootRank),
                        numRanks);
   checkDeviceTensors(outputs);
-  c10d::assertSingleElementOutput(invalidArgument, outputs);
+  c10d::assertSingleElementOutput(invalid_arg_func, outputs);
   auto output = outputs.back();
   std::vector<at::Tensor> inputTensors;
 
   if (curRank == opts.rootRank) {
-    if (inputs.size() != 1) {
-      std::stringstream ss;
-      ss << "requires a single-element input list containing a list with "
-         << numRanks << " tensors.";
-      invalidArgument(ss.str());
-    } else if (inputs[0].size() != static_cast<size_t>(numRanks)) {
-      std::stringstream ss;
-      ss << "Incorrect input list size " << inputs[0].size()
-         << ". Input list size should be " << numRanks
-         << ", same as size of the process group.";
-      invalidArgument(ss.str());
-    }
-
-    const auto& options = output.options();
-    const auto& sizes = output.sizes();
-    c10d::assertTypeAndSizesMatch(invalidArgument, inputs[0], options, sizes);
+    checkGatherScatterRootRank(inputs, output, numRanks, invalid_arg_func);
     inputTensors = inputs[0];
   } else {
     if (!inputs.empty()) {
-      invalidArgument("requires empty input on non-root");
+      invalid_arg_func("requires empty input on non-root");
     }
     inputTensors = {};
     inputTensors.emplace_back();
@@ -784,19 +785,9 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::scatter(
       outputs, inputTensors,
       [&](at::Tensor& /* unused */, at::Tensor& /* unused */, diclComm_t comm,
           DIPUStream& stream) {
-        const auto root = static_cast<int>(opts.rootRank);
-        void** scatter_input_ptr = nullptr;
-        std::vector<void*> root_input_ptr_vec;
-        size_t outputDataBytes =
-            output.unsafeGetTensorImpl()->unsafe_storage().nbytes();
-
+        std::vector<void*> input_ptr_vec = {};
         if (curRank == root) {
-          root_input_ptr_vec = {};
-          for (auto& inputTensor : inputTensors) {
-            root_input_ptr_vec.push_back(inputTensor.data_ptr());
-            dipu::recordStream(inputTensor, stream);
-          }
-          scatter_input_ptr = root_input_ptr_vec.data();
+          combineTenorsPtrRecordStream(inputTensors, input_ptr_vec, stream);
         }
 
         RECORD_FUNCTION(
@@ -805,9 +796,10 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::scatter(
         profile::RecordBlockCreator _("DiclScatter", stream.rawstream(),
                                       static_cast<int>(stream.id()));
         return devproxy::diclScatter(
-            scatter_input_ptr, output.data_ptr(),
-            static_cast<size_t>(output.numel()), output.scalar_type(), root,
-            curRank, numRanks, outputDataBytes, comm, stream.rawstream());
+            input_ptr_vec.empty() ? nullptr : input_ptr_vec.data(),
+            output.data_ptr(), static_cast<size_t>(output.numel()),
+            output.scalar_type(), root, curRank, numRanks, comm,
+            stream.rawstream());
       },
       OpType::SCATTER);
 }

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -779,6 +779,7 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::scatter(
     inputTensors.emplace_back();
   }
 
+  // NOLINTNEXTLINE(readability-suspicious-call-argument)
   return collective(
       outputs, inputTensors,
       [&](at::Tensor& /* unused */, at::Tensor& /* unused */, diclComm_t comm,

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
@@ -26,10 +26,10 @@ using c10d::Backend;
 using c10d::BarrierOptions;
 using c10d::BroadcastOptions;
 using c10d::GatherOptions;
-using c10d::ScatterOptions;
 using c10d::OpType;
 using c10d::ReduceOptions;
 using c10d::ReduceScatterOptions;
+using c10d::ScatterOptions;
 using c10d::Store;
 using c10d::Work;
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
@@ -26,6 +26,7 @@ using c10d::Backend;
 using c10d::BarrierOptions;
 using c10d::BroadcastOptions;
 using c10d::GatherOptions;
+using c10d::ScatterOptions;
 using c10d::OpType;
 using c10d::ReduceOptions;
 using c10d::ReduceScatterOptions;
@@ -59,7 +60,7 @@ constexpr int64_t diclSyncBusyWaitMillis = 30;
  * Therefore, WorkDICL::exception() is not supported, and WorkDICL::isSuccess()
  * will always return true if the operation has completed.
  *
- * @warning Not supporting gather and all _coalesced functions now. We will add
+ * @warning Not supporting all _coalesced functions now. We will add
  * them in the future if needed.
  *
  * Example on using DICL process group:
@@ -195,6 +196,11 @@ class DIPU_API ProcessGroupDICL : public Backend {
   c10::intrusive_ptr<Work> _allgather_base(
       at::Tensor& outputs, at::Tensor& inputs,
       const AllgatherOptions& opts /* = AllgatherOptions() */) override;
+
+  c10::intrusive_ptr<Work> scatter(
+      std::vector<at::Tensor>& outputs,
+      std::vector<std::vector<at::Tensor>>& inputs,
+      const ScatterOptions& opts /* = ScatterOptions() */) override;
 
   c10::intrusive_ptr<Work> reduce_scatter(
       std::vector<at::Tensor>& outputs,


### PR DESCRIPTION
在对于 lmdeploy 的支持过程中，发现 pytorch 2.0 dtensor 的 distribute_tensor 需要用到 dicl scatter 操作，lmdeploy _tp_build_model._broadcast_config 中的 dist.gather_object 需要用到 dicl gather 操作。
本 PR 使用 diclSend 和 diclRecv 实现单个 diclComm 下的 diclScatter 和 diclGather。