### PR TITLE
[DIPU] change at::empty to nodispatch::empty at require tensor function

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/aten/ops/NodispatchUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/NodispatchUtils.hpp
@@ -55,6 +55,14 @@ inline at::Tensor empty_strided(at::IntArrayRef size, at::IntArrayRef stride,
       options.layout_opt(), options.device_opt(), options.pinned_memory_opt());
 }
 
+inline at::Tensor empty_strided_cpu(at::IntArrayRef size,
+                                    at::IntArrayRef stride,
+                                    at::TensorOptions options = {}) {
+  return dipu_aten::empty_strided_cpu(
+      size, stride, c10::optTypeMetaToScalarType(options.dtype_opt()),
+      options.layout_opt(), options.device_opt(), options.pinned_memory_opt());
+}
+
 inline at::Tensor empty_like(
     const at::Tensor& self, c10::optional<at::ScalarType> dtype,
     c10::optional<at::Layout> layout, c10::optional<at::Device> device,

--- a/dipu/torch_dipu/csrc_dipu/diopirt/diopirt_impl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/diopirt/diopirt_impl.cpp
@@ -133,9 +133,9 @@ DIOPI_RT_API diopiError_t diopiRequireTensor(diopiContextHandle_t ctx,
   at::Tensor t;
   if (stride) {
     at::IntArrayRef at_stride(stride->data, stride->len);
-    t = at::empty_strided(at_dims, at_stride, options);
+    t = nodispatch::empty_strided(at_dims, at_stride, options);
   } else {
-    t = at::empty(at_dims, options);
+    t = nodispatch::empty(at_dims, options);
   }
 
   ctx->arrays.emplace_back(std::move(t));

--- a/dipu/torch_dipu/csrc_dipu/diopirt/diopirt_impl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/diopirt/diopirt_impl.cpp
@@ -144,9 +144,11 @@ DIOPI_RT_API diopiError_t diopiRequireTensor(diopiContextHandle_t ctx,
   } else {
     if (stride) {
       at::IntArrayRef at_stride(stride->data, stride->len);
-      t = at::empty_strided(at_dims, at_stride, options);
+      t = dipu::native::nodispatch::empty_strided_cpu(at_dims, at_stride,
+                                                      options);
     } else {
-      t = at::empty(at_dims, options);
+      t = dipu::native::nodispatch::empty_cpu(at_dims, at_type.toScalarType(),
+                                              at_device);
     }
   }
 

--- a/dipu/torch_dipu/csrc_dipu/diopirt/diopirt_impl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/diopirt/diopirt_impl.cpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <string>
 
+#include "csrc_dipu/aten/ops/NodispatchUtils.hpp"
 #include "csrc_dipu/profiler/profiler.h"
 
 namespace diopihelper = dipu::diopi_helper;
@@ -131,11 +132,22 @@ DIOPI_RT_API diopiError_t diopiRequireTensor(diopiContextHandle_t ctx,
   c10::DeviceType at_device = diopihelper::toATenDevice(device);
   auto options = at::TensorOptions(at_device).dtype(at_type);
   at::Tensor t;
-  if (stride) {
-    at::IntArrayRef at_stride(stride->data, stride->len);
-    t = nodispatch::empty_strided(at_dims, at_stride, options);
+  // Use nodispatch::empty to minimize dispatch operations when constructing on
+  // a device.
+  if (dipu::DIPU_DEVICE_TYPE == at_device) {
+    if (stride) {
+      at::IntArrayRef at_stride(stride->data, stride->len);
+      t = dipu::native::nodispatch::empty_strided(at_dims, at_stride, options);
+    } else {
+      t = dipu::native::nodispatch::empty(at_dims, options);
+    }
   } else {
-    t = nodispatch::empty(at_dims, options);
+    if (stride) {
+      at::IntArrayRef at_stride(stride->data, stride->len);
+      t = at::empty_strided(at_dims, at_stride, options);
+    } else {
+      t = at::empty(at_dims, options);
+    }
   }
 
   ctx->arrays.emplace_back(std::move(t));


### PR DESCRIPTION
通过timeline中分析，部分算子在调用时会有一次empty kernel的调用逻辑（比如：max）。经过分析是算子需要有输出数据的时候，在deeplink.framework中会构造一个空的数据，构造过程会调用at::empty()，从而会多一次kernel调用。现通过nodispatch的empty方式，降低empty的dispatch次数。

改造前：
![image](https://github.com/DeepLink-org/deeplink.framework/assets/14268623/b4cbff17-06bd-4156-b17c-995888757a96)

改造后：
![image](https://github.com/DeepLink-org/deeplink.framework/assets/14268623/f091df1a-c25b-457a-937c-a8484c2a308f)

