### PR TITLE
[DIPU] Implement all_to_all_single (with unequal splits) and all_to_all

### DIFF
--- a/dipu/tests/python/individual_scripts/test_rt_ddp.py
+++ b/dipu/tests/python/individual_scripts/test_rt_ddp.py
@@ -358,12 +358,41 @@ def demo_alltoall_base_equal_split(rank, world_size, port):
 
     expected = torch.cat(
         [
-            (torch.arange(split_size) + i * tensor_size + rank * split_size)
+            torch.arange(split_size) + i * tensor_size + rank * split_size
             for i in range(world_size)
         ]
     )
 
     dist.all_to_all_single(dst, src)
+    dist.barrier()
+    assert torch.allclose(expected, dst.cpu())
+    cleanup()
+
+
+def demo_alltoall_base_unequal_split(rank, world_size, port):
+    import torch_dipu
+
+    setup(rank, world_size, port)
+
+    input_split_sizes = torch.arange(world_size) + 1 + rank * world_size
+    output_split_sizes = torch.arange(0, world_size * world_size, world_size) + 1 + rank
+    src = (
+        torch.arange(input_split_sizes.sum().item())
+        + torch.arange(input_split_sizes[0]).sum().item()
+    ).to(rank)
+    dst = torch.empty(output_split_sizes.sum().item(), dtype=torch.int64).to(rank)
+
+    expected = torch.cat(
+        [
+            torch.arange(output_split_sizes[i])
+            + torch.arange(output_split_sizes[i]).sum().item()
+            for i in range(world_size)
+        ]
+    )
+
+    dist.all_to_all_single(
+        dst, src, output_split_sizes.tolist(), input_split_sizes.tolist()
+    )
     dist.barrier()
     assert torch.allclose(expected, dst.cpu())
     cleanup()
@@ -477,6 +506,7 @@ if __name__ == "__main__":
     run_demo(demo_reducescatter, world_size, port)
     run_demo(demo_reducescatter_base, world_size, port)
     run_demo(demo_alltoall_base_equal_split, world_size, port)
+    run_demo(demo_alltoall_base_unequal_split, world_size, port)
     run_demo(demo_gather, world_size, port)
     run_demo(demo_scatter, world_size, port)
 

--- a/dipu/tests/python/individual_scripts/test_rt_ddp.py
+++ b/dipu/tests/python/individual_scripts/test_rt_ddp.py
@@ -374,6 +374,16 @@ def demo_alltoall_base_unequal_split(rank, world_size, port):
 
     setup(rank, world_size, port)
 
+    # Example: For world_size = 2,
+    # input_split_sizes: [1,2] (rank 0)
+    #                    [3,4] (rank 1)
+    # output_split_sizes: [1,3] (rank 0)
+    #                     [2,4] (rank 1)
+    # src: [0, 1, 2] (rank 0)
+    #      [3, 4, 5, 6, 7, 8, 9] (rank 1)
+    # expected / dst: [0, 3, 4, 5] (rank 0)
+    #                 [1, 2, 6, 7, 8, 9] (rank 1)
+
     input_split_sizes = torch.arange(world_size) + 1 + rank * world_size
     output_split_sizes = torch.arange(0, world_size * world_size, world_size) + 1 + rank
     src = (
@@ -402,6 +412,12 @@ def demo_alltoall(rank, world_size, port):
     import torch_dipu
 
     setup(rank, world_size, port)
+
+    # Example: For world_size = 2,
+    # src: [[0], [1, 2]] (rank 0)
+    #      [[3, 4, 5], [6, 7, 8, 9]] (rank 1)
+    # expected / dst: [[0], [3, 4, 5]] (rank 0)
+    #                 [[1, 2], [6, 7, 8, 9]] (rank 1)
 
     input_split_sizes = torch.arange(world_size) + 1 + rank * world_size
     output_split_sizes = torch.arange(0, world_size * world_size, world_size) + 1 + rank

--- a/dipu/torch_dipu/csrc_dipu/runtime/device/diclapis.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/device/diclapis.h
@@ -65,6 +65,12 @@ DIPU_WEAK diclResult_t diclAllToAllEqualSplit(const void* sendBuf,
                                               diclComm_t comm,
                                               deviceStream_t stream);
 
+DIPU_WEAK diclResult_t diclAllToAllUnequalSplit(
+    const void* sendBuf, const size_t* sendCounts,
+    const size_t* sendDisplacements, void* recvBuf, const size_t* recvCounts,
+    const size_t* recvDisplacements, at::ScalarType dataType, diclComm_t comm,
+    deviceStream_t stream);
+
 DIPU_API diclResult_t diclSend(const void* sendBuf, size_t count,
                                at::ScalarType datatype, int peer,
                                diclComm_t comm, deviceStream_t stream);

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
@@ -127,7 +127,7 @@ devapis::diclResult_t diclAllToAllEqualSplit(
                                            comm, stream);
   }
 
-  // TODO(jfxu-st): For CUDA, use NCCL Group Calls for higher performance
+  // TODO(jfxu-st): For CUDA, use NCCL group calls for higher performance
   // Ref:
   // https://github.com/pytorch/pytorch/blob/f2d7f235a684c593f5a1ff2ca0b47b47274bfe85/torch/csrc/cuda/nccl.cpp#L828-L838
   // Ref:
@@ -160,7 +160,7 @@ DIPU_API devapis::diclResult_t diclAllToAllUnequalSplit(
         recvDisplacements, dataType, comm, stream);
   }
 
-  // TODO(jfxu-st): For CUDA, use NCCL Group Calls for higher performance
+  // TODO(jfxu-st): For CUDA, use NCCL group calls for higher performance
   // Ref:
   // https://github.com/pytorch/pytorch/blob/f2d7f235a684c593f5a1ff2ca0b47b47274bfe85/torch/csrc/cuda/nccl.cpp#L871-L893
 

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.cpp
@@ -137,14 +137,67 @@ devapis::diclResult_t diclAllToAllEqualSplit(
       "implementation based on devproxy::diclScatter will be used")
   const size_t numBytesPerRank = count * c10::elementSize(dataType);
   std::vector<const void*> sendBuf2d(commSize);
-  for (const auto peer : c10::irange(commSize)) {
-    sendBuf2d[peer] =
-        reinterpret_cast<const char*>(sendBuf) + peer * numBytesPerRank;
+  for (const auto scatterRootRank : c10::irange(commSize)) {
+    sendBuf2d[scatterRootRank] = reinterpret_cast<const char*>(sendBuf) +
+                                 scatterRootRank * numBytesPerRank;
   }
   for (const auto peer : c10::irange(commSize)) {
     diclScatter(sendBuf2d.data(),
                 reinterpret_cast<char*>(recvBuf) + peer * numBytesPerRank,
                 count, dataType, peer, currRank, commSize, comm, stream);
+  }
+  return devapis::DICL_SUCCESS;
+}
+
+DIPU_API devapis::diclResult_t diclAllToAllUnequalSplit(
+    const void* sendBuf, const size_t* sendCounts,
+    const size_t* sendDisplacements, void* recvBuf, const size_t* recvCounts,
+    const size_t* recvDisplacements, at::ScalarType dataType, diclComm_t comm,
+    deviceStream_t stream, int currRank, int commSize) {
+  if (devapis::diclAllToAllUnequalSplit) {
+    return devapis::diclAllToAllUnequalSplit(
+        sendBuf, sendCounts, sendDisplacements, recvBuf, recvCounts,
+        recvDisplacements, dataType, comm, stream);
+  }
+
+  // TODO(jfxu-st): For CUDA, use NCCL Group Calls for higher performance
+  // Ref:
+  // https://github.com/pytorch/pytorch/blob/f2d7f235a684c593f5a1ff2ca0b47b47274bfe85/torch/csrc/cuda/nccl.cpp#L871-L893
+
+  TORCH_WARN_ONCE(
+      "devapis::diclAllToAllUnequalSplit is not implemented, so a fallback "
+      "implementation based on devproxy::diclSend and devproxy::diclRecv will "
+      "be used")
+
+  size_t elementSize = c10::elementSize(dataType);
+  for (const auto scatterRootRank : c10::irange(commSize)) {
+    if (currRank != scatterRootRank) {
+      DIPU_CALL_DICLAPIS(
+          diclRecv(reinterpret_cast<char*>(recvBuf) +
+                       recvDisplacements[scatterRootRank] * elementSize,
+                   recvCounts[scatterRootRank], dataType, scatterRootRank, comm,
+                   stream));
+      continue;
+    }
+
+    for (const auto dstRank : c10::irange(commSize)) {
+      if (dstRank == scatterRootRank) {
+        continue;
+      }
+      DIPU_CALL_DICLAPIS(diclSend(reinterpret_cast<const char*>(sendBuf) +
+                                      sendDisplacements[dstRank] * elementSize,
+                                  sendCounts[dstRank], dataType, dstRank, comm,
+                                  stream));
+    }
+
+    auto deviceId = static_cast<devapis::deviceId_t>(currRank);
+    devproxy::memCopyD2DAsync(stream, sendCounts[currRank] * elementSize,
+                              deviceId,
+                              reinterpret_cast<char*>(recvBuf) +
+                                  recvDisplacements[currRank] * elementSize,
+                              deviceId,
+                              reinterpret_cast<const char*>(sendBuf) +
+                                  sendDisplacements[currRank] * elementSize);
   }
   return devapis::DICL_SUCCESS;
 }

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
@@ -74,6 +74,15 @@ DIPU_API devapis::diclResult_t diclAllToAllEqualSplit(
        devapis::diclAllToAllEqualSplit is not implemented */
     int currRank, int commSize);
 
+DIPU_API devapis::diclResult_t diclAllToAllUnequalSplit(
+    const void* sendBuf, const size_t* sendCounts,
+    const size_t* sendDisplacements, void* recvBuf, const size_t* recvCounts,
+    const size_t* recvDisplacements, at::ScalarType dataType, diclComm_t comm,
+    deviceStream_t stream,
+    /* The following arguments are only used for a fallback implementation when
+       devapis::diclAllToAllEqualSplit is not implemented */
+    int currRank, int commSize);
+
 DIPU_API devapis::diclResult_t diclSend(const void* sendbuff, size_t count,
                                         at::ScalarType datatype, int peer,
                                         diclComm_t comm, deviceStream_t stream);

--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/diclproxy.h
@@ -80,7 +80,7 @@ DIPU_API devapis::diclResult_t diclAllToAllUnequalSplit(
     const size_t* recvDisplacements, at::ScalarType dataType, diclComm_t comm,
     deviceStream_t stream,
     /* The following arguments are only used for a fallback implementation when
-       devapis::diclAllToAllEqualSplit is not implemented */
+       devapis::diclAllToAllUnequalSplit is not implemented */
     int currRank, int commSize);
 
 DIPU_API devapis::diclResult_t diclSend(const void* sendbuff, size_t count,

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.cpp
@@ -324,22 +324,6 @@ void check_device_single_tensor(
   }
 }
 
-// Ref:
-// https://github.com/pytorch/pytorch/blob/799acd31b4ca1c709f1e66dc58f22638e1f7696c/torch/csrc/distributed/c10d/Utils.hpp#L498C1-L514C2
-inline void check_split_sizes(const std::vector<int64_t>& split_sizes,
-                              const at::Tensor& tensor, int group_size) {
-  if (split_sizes.empty()) {
-    TORCH_CHECK(tensor.size(0) % group_size == 0,
-                "Tensor's dim 0 does not divide equally across group size");
-  } else {
-    TORCH_CHECK(split_sizes.size() == static_cast<size_t>(group_size),
-                "Number of tensor splits not equal to group size");
-    const auto sum = c10::sum_integers(split_sizes);
-    TORCH_CHECK(sum == tensor.size(0),
-                "Split sizes doesn't match total dim 0 size");
-  }
-}
-
 // Check that all `tensors'
 void checkDeviceTensors(const std::vector<at::Tensor>& tensors) {
   if (tensors.empty()) {
@@ -415,32 +399,6 @@ std::vector<at::Tensor> flatten_for_scatter_gather(
     flattened[i] = c10d::newLikeFlat(tensor_lists, i);
   }
   return flattened;
-}
-
-// Ref:
-// https://github.com/pytorch/pytorch/blob/54b0006cb232f798281397b2261101625444c79b/torch/csrc/distributed/c10d/Utils.hpp#L517C1-L542C2
-template <typename T>
-size_t compute_lengths_and_offsets_for_all_to_all(
-    const std::vector<int64_t>& split_sizes, const at::Tensor& tensor,
-    std::vector<T>* lengths, std::vector<T>* offsets) {
-  size_t group_size = lengths->size();
-  bool equal_splits = false;
-  size_t dim0_size = tensor.size(0);
-  size_t row_size = (dim0_size ? tensor.numel() / dim0_size : 1);
-  size_t split_size = 0;
-  size_t offset = 0;
-
-  if (split_sizes.empty()) {
-    equal_splits = true;
-    split_size = tensor.size(0) / group_size;
-  }
-  for (const auto i : c10::irange(group_size)) {
-    size_t length = row_size * (equal_splits ? split_size : split_sizes[i]);
-    (*lengths)[i] = length;
-    (*offsets)[i] = offset;
-    offset += length;
-  }
-  return offset;
 }
 
 template <bool RecordDest, typename Dest, typename Src>
@@ -947,8 +905,8 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::alltoall_base(
         OpType::ALLTOALL_BASE);
   }
 
-  check_split_sizes(inputSplitSizes, inputTensor, size_);
-  check_split_sizes(outputSplitSizes, outputTensor, size_);
+  c10d::checkSplitSizes(inputSplitSizes, inputTensor, size_);
+  c10d::checkSplitSizes(outputSplitSizes, outputTensor, size_);
   auto outputs = std::vector<at::Tensor>{outputTensor};
   auto inputs = std::vector<at::Tensor>{inputTensor};
   return collective(
@@ -959,10 +917,10 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::alltoall_base(
         std::vector<size_t> inputCounts(size_);
         std::vector<size_t> outputDisplacements(size_);
         std::vector<size_t> inputDisplacements(size_);
-        compute_lengths_and_offsets_for_all_to_all(
-            outputSplitSizes, output, &outputCounts, &outputDisplacements);
-        compute_lengths_and_offsets_for_all_to_all(
-            inputSplitSizes, input, &inputCounts, &inputDisplacements);
+        c10d::computeLengthsAndOffsets(outputSplitSizes, output, &outputCounts,
+                                       &outputDisplacements);
+        c10d::computeLengthsAndOffsets(inputSplitSizes, input, &inputCounts,
+                                       &inputDisplacements);
         RECORD_FUNCTION("DiclAlltoAllUnequalSplit",
                         std::vector<c10::IValue>({input}));
         profile::RecordBlockCreator _("DiclAlltoAllUnequalSplit",
@@ -1027,10 +985,10 @@ c10::intrusive_ptr<Work> ProcessGroupDICL::alltoall(
         std::vector<size_t> inputCounts(size_);
         std::vector<size_t> outputDisplacements(size_);
         std::vector<size_t> inputDisplacements(size_);
-        compute_lengths_and_offsets_for_all_to_all(
-            outputSplitSizes, output, &outputCounts, &outputDisplacements);
-        compute_lengths_and_offsets_for_all_to_all(
-            inputSplitSizes, input, &inputCounts, &inputDisplacements);
+        c10d::computeLengthsAndOffsets(outputSplitSizes, output, &outputCounts,
+                                       &outputDisplacements);
+        c10d::computeLengthsAndOffsets(inputSplitSizes, input, &inputCounts,
+                                       &inputDisplacements);
         RECORD_FUNCTION("DiclAlltoAllUnequalSplit",
                         std::vector<c10::IValue>({input}));
         profile::RecordBlockCreator _("DiclAlltoAllUnequalSplit",

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
@@ -213,11 +213,16 @@ class DIPU_API ProcessGroupDICL : public Backend {
       at::Tensor& output, at::Tensor& input,
       const ReduceScatterOptions& opts /* = ReduceScatterOptions() */) override;
 
-  c10::intrusive_ptr<Work> alltoall_base(at::Tensor& outputTensor,
-                                         at::Tensor& inputTensor,
-                                         std::vector<int64_t>& outputSplitSizes,
-                                         std::vector<int64_t>& inputSplitSizes,
-                                         const AllToAllOptions& opts) override;
+  c10::intrusive_ptr<Work> alltoall_base(
+      at::Tensor& outputTensor, at::Tensor& inputTensor,
+      std::vector<int64_t>& outputSplitSizes,
+      std::vector<int64_t>& inputSplitSizes,
+      const AllToAllOptions& opts = AllToAllOptions()) override;
+
+  c10::intrusive_ptr<Work> alltoall(
+      std::vector<at::Tensor>& outputTensors,
+      std::vector<at::Tensor>& inputTensors,
+      const AllToAllOptions& opts = AllToAllOptions()) override;
 
   c10::intrusive_ptr<Work> send(std::vector<at::Tensor>& tensors, int dstRank,
                                 int tag) override;

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/ProcessGroupDICL.h
@@ -213,16 +213,15 @@ class DIPU_API ProcessGroupDICL : public Backend {
       at::Tensor& output, at::Tensor& input,
       const ReduceScatterOptions& opts /* = ReduceScatterOptions() */) override;
 
-  c10::intrusive_ptr<Work> alltoall_base(
-      at::Tensor& outputTensor, at::Tensor& inputTensor,
-      std::vector<int64_t>& outputSplitSizes,
-      std::vector<int64_t>& inputSplitSizes,
-      const AllToAllOptions& opts = AllToAllOptions()) override;
+  c10::intrusive_ptr<Work> alltoall_base(at::Tensor& outputTensor,
+                                         at::Tensor& inputTensor,
+                                         std::vector<int64_t>& outputSplitSizes,
+                                         std::vector<int64_t>& inputSplitSizes,
+                                         const AllToAllOptions& opts) override;
 
-  c10::intrusive_ptr<Work> alltoall(
-      std::vector<at::Tensor>& outputTensors,
-      std::vector<at::Tensor>& inputTensors,
-      const AllToAllOptions& opts = AllToAllOptions()) override;
+  c10::intrusive_ptr<Work> alltoall(std::vector<at::Tensor>& outputTensors,
+                                    std::vector<at::Tensor>& inputTensors,
+                                    const AllToAllOptions& opts) override;
 
   c10::intrusive_ptr<Work> send(std::vector<at::Tensor>& tensors, int dstRank,
                                 int tag) override;

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/c10dOps.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/c10dOps.cpp
@@ -187,6 +187,19 @@ c10::intrusive_ptr<Work> alltoall_base_dipu_(
                       AllToAllOptions{std::chrono::milliseconds(timeout)});
 }
 
+std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> alltoall_dipu_(
+    const at::TensorList& output_tensors, const at::TensorList& input_tensors,
+    const c10::intrusive_ptr<ProcessGroup>& process_group, int64_t timeout) {
+  auto output_tensors_vec = output_tensors.vec();
+  auto input_tensors_vec = input_tensors.vec();
+  auto work =
+      process_group->getBackend(dipu::DIPU_DEVICE_TYPE)
+          ->alltoall(output_tensors_vec, input_tensors_vec,
+                     AllToAllOptions{std::chrono::milliseconds(timeout)});
+  return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
+      std::move(output_tensors_vec), work);
+}
+
 c10::intrusive_ptr<Work> barrier_dipu(
     at::Tensor /* unused */,  // NOLINT(performance-unnecessary-value-param)
     const c10::intrusive_ptr<ProcessGroup>& process_group,
@@ -216,6 +229,7 @@ TORCH_LIBRARY_IMPL(c10d, DIPU_DEVICE_TYPE_MACRO, m) {
   m.impl("reduce_scatter_", reduce_scatter_dipu_);
   m.impl("_reduce_scatter_base_", _reduce_scatter_base_dipu_);
   m.impl("alltoall_base_", alltoall_base_dipu_);
+  m.impl("alltoall_", alltoall_dipu_);
   m.impl("barrier", barrier_dipu);
 
   // not implement

--- a/dipu/torch_dipu/csrc_dipu/runtime/distributed/c10dOps.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/distributed/c10dOps.cpp
@@ -196,8 +196,7 @@ std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>> alltoall_dipu_(
       process_group->getBackend(dipu::DIPU_DEVICE_TYPE)
           ->alltoall(output_tensors_vec, input_tensors_vec,
                      AllToAllOptions{std::chrono::milliseconds(timeout)});
-  return std::tuple<std::vector<at::Tensor>, c10::intrusive_ptr<Work>>(
-      std::move(output_tensors_vec), work);
+  return {std::move(output_tensors_vec), work};
 }
 
 c10::intrusive_ptr<Work> barrier_dipu(

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/communicatorimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/communicatorimpl.cpp
@@ -159,6 +159,18 @@ DIPU_API diclResult_t diclAllToAllEqualSplit(const void* sendBuf, void* recvBuf,
   return DICL_SUCCESS;
 }
 
+DIPU_API diclResult_t diclAllToAllUnequalSplit(
+    const void* sendBuf, const size_t* sendCounts,
+    const size_t* sendDisplacements, void* recvBuf, const size_t* recvCounts,
+    const size_t* recvDisplacements, at::ScalarType dataType, diclComm_t comm,
+    deviceStream_t stream) {
+  HcclDataType hcclDataType = getHcclDataType(dataType);
+  HCCL_THROW(HcclAlltoAllV(sendBuf, sendCounts, sendDisplacements, hcclDataType,
+                           recvBuf, recvCounts, recvDisplacements, hcclDataType,
+                           comm, stream));
+  return DICL_SUCCESS;
+}
+
 DIPU_API diclResult_t diclSend(const void* sendBuf, size_t count,
                                at::ScalarType dataType, int peer,
                                diclComm_t comm, deviceStream_t stream) {


### PR DESCRIPTION
- Done
  - Implement all_to_all_single with equal splits
  - Implement all_to_all
- Leave to the future
  - For cuda, use nccl group calls for all_to_all_single and all_to_all (We need to design some new APIs to support group calls)
  - Implement a more performant fallback for all_to_all without using a flattened tensor for relay