### PR TITLE
fix cuda copy

### DIFF
--- a/dipu/tests/python/unittests/test_copy.py
+++ b/dipu/tests/python/unittests/test_copy.py
@@ -130,6 +130,13 @@ class TestCopy(TestCase):
         for i in range(500):
             assert torch.all(tensor_list[i] == float(i))
 
+    def test_h2d_copy_blocking(self):
+        a = torch.ones(1000000, pin_memory=True)
+        b = torch.zeros(1000000, device="cuda")
+        b.copy_(a, non_blocking=False)
+        a[-1].fill_(-1)
+        assert torch.all(b == 1)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/dipu/tests/python/unittests/test_copy.py
+++ b/dipu/tests/python/unittests/test_copy.py
@@ -2,7 +2,7 @@
 import itertools
 import torch
 import torch_dipu
-from torch_dipu.testing._internal.common_utils import TestCase, run_tests
+from torch_dipu.testing._internal.common_utils import TestCase, run_tests, skipOn
 
 
 class TestCopy(TestCase):
@@ -130,6 +130,7 @@ class TestCopy(TestCase):
         for i in range(500):
             assert torch.all(tensor_list[i] == float(i))
 
+    @skipOn("DROPLET", "not support pin memory on droplet")
     def test_h2d_copy_blocking(self):
         a = torch.ones(1000000, pin_memory=True)
         b = torch.zeros(1000000, device="cuda")

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
@@ -59,47 +59,6 @@ inline void checkOverlap(const at::Tensor& dst, const at::Tensor& src) {
   assert_no_partial_overlap(dst, src);
 }
 
-inline void tryRecordOrSyncStream(const at::Tensor& dst, const at::Tensor& src,
-                                  DIPUStream& cur_stream, bool block_cpu) {
-  const bool is_default_stream = (dipu::getDefaultDIPUStream() == cur_stream);
-  bool is_all_device_tensor = (!dst.is_cpu() && !src.is_cpu());
-  // When copy from device to device, torch allocator ensure that malloc and
-  // free are in the same stream, so it is not necessary to recordStream.
-  if (is_all_device_tensor) {
-    if (!isTorchAllocator() && !is_default_stream) {
-      recordStream(dst, cur_stream);
-      recordStream(src, cur_stream);
-    }
-    return;
-  }
-
-  const at::Tensor& cpu_tensor = (dst.is_cpu() ? dst : src);
-  const at::Tensor& device_tensor = (dst.is_cpu() ? src : dst);
-  bool is_pinned = isPinnedPtr(cpu_tensor.storage().data());
-  // When copy between cpu tensor(not pinned) and device tensor, do sync stream
-  // to ensure free safety while block_cpu is True.
-  if (!is_pinned) {
-    if (block_cpu) {
-      dipu::devapis::syncStream(cur_stream.rawstream());
-    }
-    return;
-  }
-
-  // copy between pin memory cpu tensor and device tensor
-  if (!isTorchAllocator()) {
-    recordStream(cpu_tensor, cur_stream);
-    if (!is_default_stream) {
-      recordStream(device_tensor, cur_stream);
-    }
-    return;
-  }
-
-  TORCH_CHECK(allocator::CachingHostAllocator_recordEvent(
-                  cpu_tensor.data_ptr(),
-                  cpu_tensor.storage().data_ptr().get_context(), cur_stream),
-              "CachingHostAllocator_recordEvent fail");
-}
-
 inline DIPUCopyType getCopyType(const at::Tensor& dst, const at::Tensor& src) {
   bool isSrcDevice = dipu::isDeviceTensor(src);
   bool isDstDevice = dipu::isDeviceTensor(dst);
@@ -275,6 +234,101 @@ inline void doDstStreamWaitSrcStream(const CopyParamsInfo& info,
   }
 }
 
+// process sync logic when copy between device and device
+// 1. when on same device, non_blocking will always be True and no need sync
+// stream.
+// 2. when on difference device
+//    2.1 non_blocking=False, sync stream.
+//    2.2 non_blocking=True, recordStream to ensure tensor free
+//    safety and doDstStreamWaitSrcStream to copy complete before used.
+inline void tryRecordOrSyncStreamD2D(const CopyParamsInfo& info,
+                                     const at::Tensor& dst,
+                                     const at::Tensor& src,
+                                     DIPUStream& cur_stream, bool non_blocking,
+                                     bool block_cpu) {
+  if (!non_blocking) {
+    cur_stream.synchronize();
+    return;
+  }
+
+  if (!isTorchAllocator()) {
+    const bool is_default_stream = (dipu::getDefaultDIPUStream() == cur_stream);
+    if (!is_default_stream) {
+      recordStream(dst, cur_stream);
+      recordStream(src, cur_stream);
+    }
+  }
+  if (info.copyType_ == DIPUCopyType::D2OtherD) {
+    doDstStreamWaitSrcStream(info, block_cpu);
+  }
+}
+
+// process sync logic when copy between host and device
+// 1. non_blocking=False, sync stream
+// 2. when cpu tensor is not pinned
+inline void tryRecordOrSyncStreamHD(const CopyParamsInfo& info,
+                                    const at::Tensor& dst,
+                                    const at::Tensor& src,
+                                    DIPUStream& cur_stream, bool non_blocking,
+                                    bool block_cpu) {
+  if (info.copyType_ == DIPUCopyType::H2H) {
+    return;
+  }
+  if (!non_blocking) {
+    cur_stream.synchronize();
+    return;
+  }
+
+  const at::Tensor& cpu_tensor =
+      (info.copyType_ == DIPUCopyType::H2D ? src : dst);
+  const at::Tensor& device_tensor =
+      (info.copyType_ == DIPUCopyType::H2D ? dst : src);
+  bool is_pinned = isPinnedPtr(cpu_tensor.storage().data());
+  // When copy between cpu tensor(not pinned) and device tensor, do sync stream
+  // to ensure free safety while block_cpu is True.
+  if (!is_pinned && block_cpu) {
+    cur_stream.synchronize();
+    return;
+  }
+
+  // copy between pin memory cpu tensor and device tensor
+  if (!isTorchAllocator()) {
+    if (is_pinned) {
+      recordStream(cpu_tensor, cur_stream);
+    }
+    const bool is_default_stream = (dipu::getDefaultDIPUStream() == cur_stream);
+    if (!is_default_stream) {
+      recordStream(device_tensor, cur_stream);
+    }
+    return;
+  }
+
+  if (is_pinned) {
+    TORCH_CHECK(allocator::CachingHostAllocator_recordEvent(
+                    cpu_tensor.data_ptr(),
+                    cpu_tensor.storage().data_ptr().get_context(), cur_stream),
+                "CachingHostAllocator_recordEvent fail");
+  }
+}
+
+inline void tryRecordOrSyncStream(const CopyParamsInfo& info,
+                                  const at::Tensor& dst, const at::Tensor& src,
+                                  DIPUStream& cur_stream, bool non_blocking,
+                                  bool block_cpu_d2d, bool block_cpu_h2d) {
+  bool is_all_device_tensor = (info.copyType_ == DIPUCopyType::D2Self ||
+                               info.copyType_ == DIPUCopyType::D2OtherD);
+  // When copy from device to device, torch allocator ensure that malloc and
+  // free are in the same stream, so it is not necessary to recordStream.
+  if (is_all_device_tensor) {
+    tryRecordOrSyncStreamD2D(info, dst, src, cur_stream, non_blocking,
+                             block_cpu_d2d);
+    return;
+  }
+
+  tryRecordOrSyncStreamHD(info, dst, src, cur_stream, non_blocking,
+                          block_cpu_h2d);
+}
+
 class DIPUCopyBase {
  public:
   DIPUCopyBase() = default;
@@ -343,17 +397,13 @@ class DIPUCopyInplace : public DIPUCopyBase {
   virtual void copyPostProcess(const at::Tensor& dst, const at::Tensor& src,
                                bool non_blocking, const CopyParamsInfo& info,
                                DIPUStream& curStream) {
-    // If non_blocking is False, sync stream after copy.
-    // If non_blocking is True, record stream to ensure tensor free safety.
-    if (!non_blocking) {
-      curStream.synchronize();
-    } else {
-      tryRecordOrSyncStream(dst, src, curStream, true);
-    }
-    if (DIPUCopyType::D2OtherD == info.copyType_) {
-      // dst wait src ready
-      doDstStreamWaitSrcStream(info, false);
-    }
+    // 1. block_cpu_d2d=False default, because we do not need sync stream when
+    // copy on two devices, just wait between stream.
+    // 2. block_cpu_h2d=True default, We need sync stream if cpu tensor is not
+    // pin memory to ensure tensor free safety.
+    tryRecordOrSyncStream(info, dst, src, curStream, non_blocking,
+                          /* block_cpu_d2d = */ false,
+                          /* block_cpu_h2d = */ true);
   }
 
   /*

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendCopyInplace.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendCopyInplace.cpp
@@ -49,14 +49,13 @@ class AscendCopyInplace : public DIPUCopyInpOnDIOPI {
     // d2h/h2d cases, the (Sync + memCopySync) strategy is adopted (see the
     // comments in the above functions copyPreProcess and directMemCopy), so
     // synchronization is never needed here.
-    // record after copy
-    if (non_blocking) {
-      tryRecordOrSyncStream(dst, src, curStream, true);
-    }
-
-    if (DIPUCopyType::D2OtherD == info.copyType_) {
-      doDstStreamWaitSrcStream(info, true);
-    }
+    // 1. block_cpu_d2d=True on ascend, dst wait src stream not working on
+    // ascend, will cause accuracy problem.
+    // 2. block_cpu_h2d=True on ascend, We need sync stream if cpu tensor is not
+    // pin memory to ensure tensor free safety.
+    tryRecordOrSyncStream(info, dst, src, curStream, non_blocking,
+                          /* block_cpu_d2d = */ true,
+                          /* block_cpu_h2d = */ true);
   }
 };
 

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendCopyInplace.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendCopyInplace.cpp
@@ -49,6 +49,14 @@ class AscendCopyInplace : public DIPUCopyInpOnDIOPI {
     // d2h/h2d cases, the (Sync + memCopySync) strategy is adopted (see the
     // comments in the above functions copyPreProcess and directMemCopy), so
     // synchronization is never needed here.
+
+    // We use sync + memCopySync on ascend when non_blocking=False and copyType
+    // in [H2D, D2H]. No need to do any sync or record stream in this situation.
+    if (!non_blocking && (DIPUCopyType::H2D == info.copyType_ ||
+                          DIPUCopyType::D2H == info.copyType_)) {
+      return;
+    }
+
     // 1. block_cpu_d2d=True on ascend, dst wait src stream not working on
     // ascend, will cause accuracy problem.
     // 2. block_cpu_h2d=True on ascend, We need sync stream if cpu tensor is not


### PR DESCRIPTION
1. copy算子代码优化
2. 修复cuda下copy算子的bug，详见test_copy.py算子新增测例。当前non_blocking=False，cpu端的修改会影响copy到device的结果，因为copyPostProcess里面没有执行sync stream，该pr修复了这个问题