### PR TITLE
[DICP]: use AscendGECompileAclRunJob as default

### DIFF
--- a/dicp/dicp/vendor/AscendGraph/codegen/ascend.py
+++ b/dicp/dicp/vendor/AscendGraph/codegen/ascend.py
@@ -488,7 +488,7 @@ class AscendCodegen(torch.fx.Interpreter):
     def gen_compile_graph_code(self):
         compile_graph_code = IndentedBuffer()
         graph_json = self.gen_graph_json()
-        compile_job_type = os.environ.get("DICP_ASCEND_COMPILE_JOB_TYPE", "AscendGECompileGERunJob")
+        compile_job_type = os.environ.get("DICP_ASCEND_COMPILE_JOB_TYPE", "AscendGECompileAclRunJob")
         assert compile_job_type in ["AscendGECompileGERunJob", "AscendGECompileAclRunJob"]
         compile_graph_code.splice(
             f"""


### PR DESCRIPTION
### Motivation and Context 背景
use AscendGECompileAclRunJob as default

### Description 描述 功能抽象
使用 ge graph run 相关接口

### 类别 （Bug 修复|new feature| Intenal SW ）
Bug 修复