### PR TITLE
perf(dipu): faster aten::mul in cuda & muxi

### DIFF
--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -650,10 +650,10 @@ def create_device_check_code(fun_config):
 
     for args in set(tensors):
         if not args.endswith("?"):
-            code += f'  TORCH_CHECK(({args}.defined() == false) || ({args}.device().type() == dipu::DIPU_DEVICE_TYPE || check_scalar_on_cpu({args})), __FILE__, ":", __LINE__, ": {op_name}: {args} should be on dipu");\n'
+            code += f'  TORCH_CHECK(({args}.defined() == false) || ({args}.device().type() == dipu::DIPU_DEVICE_TYPE || (kDipuVendorDeviceType == devapis::VendorDeviceType::CUDA && is_scalar_tensor({args}))), __FILE__, ":", __LINE__, ": {op_name}: {args} should be on dipu");\n'
         else:
             args = args[0:-1]
-            code += f'  TORCH_CHECK(({args}.has_value() == false) || ({args}.value().defined() == false) || ({args}.value().device().type() == dipu::DIPU_DEVICE_TYPE || check_scalar_on_cpu({args})), __FILE__, ":", __LINE__, "{op_name}: {args} should be on dipu");\n'
+            code += f'  TORCH_CHECK(({args}.has_value() == false) || ({args}.value().defined() == false) || ({args}.value().device().type() == dipu::DIPU_DEVICE_TYPE || (kDipuVendorDeviceType == devapis::VendorDeviceType::CUDA && is_scalar_tensor({args}))), __FILE__, ":", __LINE__, "{op_name}: {args} should be on dipu");\n'
 
     if len(tensors) > 0:
         code += "}"

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -650,10 +650,10 @@ def create_device_check_code(fun_config):
 
     for args in set(tensors):
         if not args.endswith("?"):
-            code += f'  TORCH_CHECK(({args}.defined() == false) || ({args}.device().type() == dipu::DIPU_DEVICE_TYPE), __FILE__, ":", __LINE__, ": {op_name}: {args} should be on dipu");\n'
+            code += f'  TORCH_CHECK(({args}.defined() == false) || ({args}.device().type() == dipu::DIPU_DEVICE_TYPE || check_scalar_on_cpu({args})), __FILE__, ":", __LINE__, ": {op_name}: {args} should be on dipu");\n'
         else:
             args = args[0:-1]
-            code += f'  TORCH_CHECK(({args}.has_value() == false) || ({args}.value().defined() == false) || ({args}.value().device().type() == dipu::DIPU_DEVICE_TYPE), __FILE__, ":", __LINE__, "{op_name}: {args} should be on dipu");\n'
+            code += f'  TORCH_CHECK(({args}.has_value() == false) || ({args}.value().defined() == false) || ({args}.value().device().type() == dipu::DIPU_DEVICE_TYPE || check_scalar_on_cpu({args})), __FILE__, ":", __LINE__, "{op_name}: {args} should be on dipu");\n'
 
     if len(tensors) > 0:
         code += "}"

--- a/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
+++ b/dipu/scripts/autogen_diopi_wrapper/autogen_diopi_wrapper.py
@@ -650,10 +650,10 @@ def create_device_check_code(fun_config):
 
     for args in set(tensors):
         if not args.endswith("?"):
-            code += f'  TORCH_CHECK(({args}.defined() == false) || ({args}.device().type() == dipu::DIPU_DEVICE_TYPE || (kDipuVendorDeviceType == devapis::VendorDeviceType::CUDA && is_scalar_tensor({args}))), __FILE__, ":", __LINE__, ": {op_name}: {args} should be on dipu");\n'
+            code += f'  TORCH_CHECK(({args}.defined() == false) || ({args}.device().type() == dipu::DIPU_DEVICE_TYPE || ignore_device_check({args})), __FILE__, ":", __LINE__, ": {op_name}: {args} should be on dipu");\n'
         else:
             args = args[0:-1]
-            code += f'  TORCH_CHECK(({args}.has_value() == false) || ({args}.value().defined() == false) || ({args}.value().device().type() == dipu::DIPU_DEVICE_TYPE || (kDipuVendorDeviceType == devapis::VendorDeviceType::CUDA && is_scalar_tensor({args}))), __FILE__, ":", __LINE__, "{op_name}: {args} should be on dipu");\n'
+            code += f'  TORCH_CHECK(({args}.has_value() == false) || ({args}.value().defined() == false) || ({args}.value().device().type() == dipu::DIPU_DEVICE_TYPE || ignore_device_check({args})), __FILE__, ":", __LINE__, "{op_name}: {args} should be on dipu");\n'
 
     if len(tensors) > 0:
         code += "}"

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -159,11 +159,11 @@
   interface: diopiMulScalar(ctx, out, self, other)
 
 - schema: "mul_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)"
-  device: [cuda]
+  device: [cuda, muxi]
   interface: diopiMulInp(ctx, self, other)
 
 - schema: "mul_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)"
-  device: [-cuda, all]
+  device: [-cuda, -muxi, all]
   custom_code_at_the_beginning: |
     if (is_scalar_on_cpu(other)) {
         return dipu_mul__scalar(self, other.item());
@@ -171,11 +171,11 @@
   interface: diopiMulInp(ctx, self, other)
 
 - schema: "mul.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)"
-  device: [cuda]
+  device: [cuda, muxi]
   interface: diopiMul(ctx, out, self, other)
 
 - schema: "mul.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)"
-  device: [-cuda, all]
+  device: [-cuda, -muxi, all]
   custom_code_at_the_beginning: |
     // if (is_scalar_on_cpu(other)) {
     // Pytorch 2.0 has a bug, causing for_each mul passing a cpu scalar tensor. Fixed in PyTorch 2.1

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -159,22 +159,9 @@
   interface: diopiMulScalar(ctx, out, self, other)
 
 - schema: "mul_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)"
-  custom_code_at_the_beginning: |
-    if (is_scalar_on_cpu(other)) {
-        return dipu_mul__scalar(self, other.item());
-    }
   interface: diopiMulInp(ctx, self, other)
 
 - schema: "mul.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)"
-  custom_code_at_the_beginning: |
-    // if (is_scalar_on_cpu(other)) {
-    // Pytorch 2.0 has a bug, causing for_each mul passing a cpu scalar tensor. Fixed in PyTorch 2.1
-    if (is_scalar_on_cpu(other)) {
-        return dipu_mul_scalar_out(self, other.item(), out);
-    }
-    if (is_scalar_on_cpu(self)) {
-        return dipu_mul_scalar_out(other, self.item(), out);
-    }
   interface: diopiMul(ctx, out, self, other)
 
 - schema: "mul.Tensor(Tensor self, Tensor other) -> Tensor"

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -159,9 +159,32 @@
   interface: diopiMulScalar(ctx, out, self, other)
 
 - schema: "mul_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)"
+  device: [cuda]
+  interface: diopiMulInp(ctx, self, other)
+
+- schema: "mul_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)"
+  device: [-cuda, all]
+  custom_code_at_the_beginning: |
+    if (is_scalar_on_cpu(other)) {
+        return dipu_mul__scalar(self, other.item());
+    }
   interface: diopiMulInp(ctx, self, other)
 
 - schema: "mul.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)"
+  device: [cuda]
+  interface: diopiMul(ctx, out, self, other)
+
+- schema: "mul.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)"
+  device: [-cuda, all]
+  custom_code_at_the_beginning: |
+    // if (is_scalar_on_cpu(other)) {
+    // Pytorch 2.0 has a bug, causing for_each mul passing a cpu scalar tensor. Fixed in PyTorch 2.1
+    if (is_scalar_on_cpu(other)) {
+        return dipu_mul_scalar_out(self, other.item(), out);
+    }
+    if (is_scalar_on_cpu(self)) {
+        return dipu_mul_scalar_out(other, self.item(), out);
+    }
   interface: diopiMul(ctx, out, self, other)
 
 - schema: "mul.Tensor(Tensor self, Tensor other) -> Tensor"

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUOpInferrer.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUOpInferrer.cpp
@@ -79,14 +79,13 @@ void OpInferrerMeta::add_input(const at::Tensor& tensor) {
   inputs_.push_back(c10::MaybeOwned<at::Tensor>::borrowed(tensor));
 }
 
-at::Tensor OpInferrerMeta::malloc_output() {
+inline at::Tensor OpInferrerMeta::malloc_output() {
   at::TensorOptions options = at::TensorOptions().dtype(dtype_).device(device_);
-  auto out = native::nodispatch::empty(shape_, options, memory_format_);
-
   if (!strides_.empty()) {
-    out.as_strided_(shape_, strides_);
+    return native::nodispatch::empty_strided(shape_, strides_, options);
+  } else {
+    return native::nodispatch::empty(shape_, options, memory_format_);
   }
-  return out;
 }
 
 void OpInferrer::compute_dtype() {

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUOpInferrer.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUOpInferrer.cpp
@@ -83,9 +83,8 @@ inline at::Tensor OpInferrerMeta::malloc_output() {
   at::TensorOptions options = at::TensorOptions().dtype(dtype_).device(device_);
   if (!strides_.empty()) {
     return native::nodispatch::empty_strided(shape_, strides_, options);
-  } else {
-    return native::nodispatch::empty(shape_, options, memory_format_);
   }
+  return native::nodispatch::empty(shape_, options, memory_format_);
 }
 
 void OpInferrer::compute_dtype() {

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUOpInferrer.h
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUOpInferrer.h
@@ -40,7 +40,7 @@ class OpInferrerMeta {
   size_t ntensors() const { return inputs_.size(); }
 
   // Allocates the output based on the inferred attributes, use strides_ if set
-  at::Tensor malloc_output();
+  inline at::Tensor malloc_output();
 
   c10::SmallVector<c10::MaybeOwned<at::Tensor>, 4> inputs_;
   c10::DimVector shape_;

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -254,5 +254,9 @@ inline bool is_scalar_on_cpu(const at::Tensor& t) {
   return t.defined() && t.is_cpu() && t.numel() == 1;
 }
 
+inline bool check_scalar_on_cpu(const c10::optional<at::Tensor> t) {
+  return t.has_value() && (*t).unsafeGetTensorImpl()->is_wrapped_number();
+}
+
 }  // namespace native
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -254,8 +254,8 @@ inline bool is_scalar_on_cpu(const at::Tensor& t) {
   return t.defined() && t.is_cpu() && t.numel() == 1;
 }
 
-inline bool check_scalar_on_cpu(const c10::optional<at::Tensor> t) {
-  return t.has_value() && (*t).unsafeGetTensorImpl()->is_wrapped_number();
+inline bool check_scalar_on_cpu(const c10::optional<at::Tensor>& t) {
+  return t.has_value() && ((*t).unsafeGetTensorImpl()->is_wrapped_number() || ((*t).is_cpu() && (*t).numel() == 1 ));
 }
 
 }  // namespace native

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -254,10 +254,16 @@ inline bool is_scalar_on_cpu(const at::Tensor& t) {
   return t.defined() && t.is_cpu() && t.numel() == 1;
 }
 
-//This function is used to check if tensor is a scalar tensor by any means.
+// This function is used to check if tensor is a scalar tensor by any means.
 inline bool is_scalar_tensor(const c10::optional<at::Tensor>& t) {
-  return t.has_value() && ((*t).unsafeGetTensorImpl()->is_wrapped_number() || ((*t).is_cpu() && (*t).numel() == 1 ));
+  return t.has_value() && ((*t).unsafeGetTensorImpl()->is_wrapped_number() ||
+                           ((*t).is_cpu() && (*t).numel() == 1));
 }
 
+inline bool ignore_device_check(const c10::optional<at::Tensor>& t) {
+  return (kDipuVendorDeviceType == devapis::VendorDeviceType::CUDA ||
+          kDipuVendorDeviceType == devapis::VendorDeviceType::MUXI) &&
+         is_scalar_tensor(t);
+}
 }  // namespace native
 }  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/OpUtils.hpp
@@ -254,7 +254,8 @@ inline bool is_scalar_on_cpu(const at::Tensor& t) {
   return t.defined() && t.is_cpu() && t.numel() == 1;
 }
 
-inline bool check_scalar_on_cpu(const c10::optional<at::Tensor>& t) {
+//This function is used to check if tensor is a scalar tensor by any means.
+inline bool is_scalar_tensor(const c10::optional<at::Tensor>& t) {
   return t.has_value() && ((*t).unsafeGetTensorImpl()->is_wrapped_number() || ((*t).is_cpu() && (*t).numel() == 1 ));
 }
 


### PR DESCRIPTION
This change remove a redundency transformation mul_tensor->mul_scalar->mul_tensor. Also with a faster BinaryOpInferrer.
The aten::mul is almost as fast as torch in cpu avg.