### PR TITLE
Zgc/dipu fix unnecessary large memory tensor allocate and operation

### DIFF
--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -126,6 +126,8 @@
   interface: diopiDivScalar(ctx, out, self, other, mode)
 
 - schema: "aten::div.out_mode(Tensor self, Tensor other, *, str? rounding_mode, Tensor(a!) out) -> Tensor(a!)"
+  no_device_check_args: [self]
+  ins: [selfTmp]
   custom_code_at_the_beginning: |
     if (is_scalar_on_cpu(other)) {
         return dipu_div_scalar_mode_out(self, other.item(), rounding_mode, out);
@@ -137,9 +139,8 @@
     } else {
       selfTmp = self;
     }
-    auto self_tmp_handle = dipu::diopi_helper::toDiopiTensorHandle(selfTmp);
     const auto mode = toDiopiRoundMode(rounding_mode.has_value() ? rounding_mode.value().data():"none");
-  interface: diopiDiv(ctx, out, self_tmp_handle, other, mode)
+  interface: diopiDiv(ctx, out, selfTmp, other, mode)
 
 - schema: "div.Tensor_mode(Tensor self, Tensor other, *, str? rounding_mode) -> Tensor"
   dummy_call_diopi: True

--- a/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
+++ b/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml
@@ -48,8 +48,9 @@
         if (alpha.toDouble() == 1.0) {
           return dipu_add_scalar_out(other, self.item(), alpha, out);
         }
-        dipu_fill__scalar(out, self.item());
-        return dipu_add__tensor(out, other, alpha);
+        at::Tensor selfD = nodispatch::empty({1}, out.options());
+        dipu_fill__scalar(selfD, self.item());
+        return dipu_add_out(selfD, other, alpha, out);
     }
   interface: diopiAdd(ctx, out, self, other, alpha)
 
@@ -106,7 +107,7 @@
         return dipu_div_scalar_out(self, other.item(), out);
     }
     if (is_scalar_on_cpu(self)) {
-        at::Tensor selfD = nodispatch::empty_like(other);
+        at::Tensor selfD = nodispatch::empty({1}, out.options());
         dipu_fill__scalar(selfD, self.item());
         return dipu_div_out(selfD, other, out);
     }
@@ -131,7 +132,7 @@
     }
     at::Tensor selfTmp;
     if (is_scalar_on_cpu(self)) {
-        selfTmp = nodispatch::empty_like(other);
+        selfTmp = nodispatch::empty({1}, out.options());
         dipu_fill__scalar(selfTmp, self.item());
     } else {
       selfTmp = self;

--- a/dipu/tests/python/unittests/test_add.py
+++ b/dipu/tests/python/unittests/test_add.py
@@ -24,6 +24,13 @@ class TestAdd(TestCase):
         y.add_(torch.ones_like(y))
         self.assertEqual(x.cpu(), y)
 
+    def test_add_self_is_scalar(self):
+        x = torch.randn(3, 4).cuda()
+        y = x.cpu()
+        z_device = torch.add(2, x, alpha=0.3)
+        z_cpu = torch.add(2, y, alpha=0.3)
+        self.assertEqual(z_device.cpu(), z_cpu)
+
 
 if __name__ == "__main__":
     run_tests()

--- a/dipu/tests/python/unittests/test_div.py
+++ b/dipu/tests/python/unittests/test_div.py
@@ -13,11 +13,9 @@ class TestDiv(TestCase):
         y = torch.randn(1, 4).to(self.device)
         torch.div(x, y)
         z = torch.div(x, y)
-        # print(f"z = {z.cpu()}")
-
         x = x.cpu()
+
         y = y.cpu()
-        # print(torch.div(x, y))
         expected_z = torch.div(x, y)
 
         self.assertEqual(z, expected_z)
@@ -25,8 +23,6 @@ class TestDiv(TestCase):
     def test_div_scalar(self):
         a = torch.randn(3).to(self.device)
         r = torch.div(a, 0.5)
-        # print(f"a = {a.cpu()}")
-        # print(f"r = {r.cpu()}")
 
         a = a.cpu()
         expected_r = torch.div(a, 0.5)
@@ -39,7 +35,7 @@ class TestDiv(TestCase):
         for rounding_mode in ["trunc", "floor", None]:
             z_device = torch.div(2, x, rounding_mode=rounding_mode)
             z_cpu = torch.div(2, y, rounding_mode=rounding_mode)
-            self.assertEqual(z_device.cpu(), z_cpu)
+            self.assertEqual(z_device, z_cpu)
 
 
 if __name__ == "__main__":

--- a/dipu/tests/python/unittests/test_div.py
+++ b/dipu/tests/python/unittests/test_div.py
@@ -18,7 +18,7 @@ class TestDiv(TestCase):
         y = y.cpu()
         expected_z = torch.div(x, y)
 
-        self.assertEqual(z, expected_z)
+        self.assertTrue(torch.allclose(z.cpu(), expected_z, atol=1e-3, rtol=1e-3))
 
     def test_div_scalar(self):
         a = torch.randn(3).to(self.device)
@@ -27,7 +27,7 @@ class TestDiv(TestCase):
         a = a.cpu()
         expected_r = torch.div(a, 0.5)
 
-        self.assertEqual(r, expected_r)
+        self.assertTrue(torch.allclose(r.cpu(), expected_r, atol=1e-3, rtol=1e-3))
 
     def test_div_self_is_scalar(self):
         x = torch.randn(3, 4).cuda()

--- a/dipu/tests/python/unittests/test_div.py
+++ b/dipu/tests/python/unittests/test_div.py
@@ -33,6 +33,14 @@ class TestDiv(TestCase):
 
         self.assertEqual(r, expected_r)
 
+    def test_div_self_is_scalar(self):
+        x = torch.randn(3, 4).cuda()
+        y = x.cpu()
+        for rounding_mode in ["trunc", "floor", None]:
+            z_device = torch.div(2, x, rounding_mode=rounding_mode)
+            z_cpu = torch.div(2, y, rounding_mode=rounding_mode)
+            self.assertEqual(z_device.cpu(), z_cpu)
+
 
 if __name__ == "__main__":
     run_tests()


### PR DESCRIPTION
1. 修复了torch.add(1, vary_large_tensor, alpha = 0.5)和torch.div(2, vary_large_tensor) 时，申请一个和vary_large_tensor一样大小的临时tensor,再将值fill 进去的问题，减少了设备内存的浪费和不必要的访存开销

Fixed the problem that when torch.add(1, vary_large_tensor) and torch.div(2, vary_large_tensor), a temporary tensor of the same size as vary_large_tensor is allocated and then the value is filled in, which reduces the waste of device memory and unnecessary memory access overhead.