### PR TITLE
support set cpu affinity

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/runtime/devproxy/deviceproxy.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/devproxy/deviceproxy.cpp
@@ -235,12 +235,18 @@ void memCopyD2D(size_t nbytes, deviceId_t dstDevId, void* dst,
 // (synchronous) copy from host to a device
 void memCopyH2D(size_t nbytes, /*deviceId_t dstDevId,*/ void* dst,
                 /*Host srcDev,*/ const void* src) {
+  if (nbytes <= 0) {
+    return;
+  }
   return devapis::memCopyH2D(nbytes, dst, src);
 }
 
 // (synchronous) copy from a device to host
 void memCopyD2H(size_t nbytes, /*Host dstDev,*/ void* dst,
                 /*deviceId_t srcDevId,*/ const void* src) {
+  if (nbytes <= 0) {
+    return;
+  }
   return devapis::memCopyD2H(nbytes, dst, src);
 }
 


### PR DESCRIPTION
设置cpu 亲和性，让特定的几个cpu使用特定加速卡，减小线程切换的开销，提高缓存命中率。默认情况下（DIPU_CPU_AFFINITY=0），会根据当前可用cpu核心数量和当前可用所有加速卡数量自动计算出每张卡使用的cpu核心数。如果用户手动设置DIPU_CPU_AFFINITY=N, 则每张卡会使用N个cpu核。

Set CPU affinity to let specific CPUs use specific accelerator cards, reduce thread switching overhead, and improve cache hit rate. By default (DIPU_CPU_AFFINITY=0), the number of CPU cores used by each card will be automatically calculated based on the number of currently available CPU cores and the number of all currently available accelerator cards. If DIPU_CPU_AFFINITY=N, each card will use N CPU cores.