### PR TITLE
refactor(dipu): remove some maybe unused environment variables and add a dev mode into build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,5 +127,14 @@ core.*
 mmlab_pack
 
 # CMake
+CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,9 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
+
+# CMake Patch
+CMakeUserPresets.json
+
+# External projects
+*-prefix/

--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,7 @@ core.*
 
 # CI temp directory
 mmlab_pack
+
+# CMake
+CMakeCache.txt
+CMakeFiles

--- a/dipu/QuickStart.md
+++ b/dipu/QuickStart.md
@@ -77,10 +77,9 @@ pip install ./deeplink.framework/dipu
 ### 验证 DIPU
 
 ``` bash
-export DIOPI_ROOT=/home/$USER/code/dipu/third_party/DIOPI/impl/lib
 export DIPU_ROOT=/home/$USER/code/dipu/torch_dipu
-export LIBRARY_PATH=$DIPU_ROOT:$DIOPI_ROOT:$LIBRARY_PATH;
-export LD_LIBRARY_PATH=$DIPU_ROOT:$DIOPI_ROOT:$LD_LIBRARY_PATH
+export LIBRARY_PATH=$DIPU_ROOT:$LIBRARY_PATH;
+export LD_LIBRARY_PATH=$DIPU_ROOT:$LD_LIBRARY_PATH
 
 sh ./tests/python/run_tests.sh
 ```
@@ -158,10 +157,10 @@ sh ./tests/python/run_tests.sh
 
 ### 算子库拓展功能
 
-#### 算子Fallback功能
+#### 算子 Fallback 功能
 
-Fallback指的是使用算子的CPU实现，而非设备实现。  
-Fallback给定算子：
+Fallback 指的是使用算子的 CPU 实现，而非设备实现。  
+Fallback 给定算子：
 
 ```bash
 export DIPU_FORCE_FALLBACK_OPS_LIST=add.out,conv2d
@@ -184,7 +183,7 @@ python -c "import torch_dipu"
 
 #### 算子精度自动对比功能
 
-算子精度自动对比功能(autocompare)用于确保算子计算结果的正确性，通过将设备参数拷贝到CPU上，对比CPU和设备的计算结果来判断精度是否达标。以下是算子精度自动对比功能的使用例子：
+算子精度自动对比功能 (autocompare) 用于确保算子计算结果的正确性，通过将设备参数拷贝到 CPU 上，对比 CPU 和设备的计算结果来判断精度是否达标。以下是算子精度自动对比功能的使用例子：
 
 ```shell
 $ unset  DIPU_FORCE_FALLBACK_OPS_LIST # 主要是确保要比较的算子没有强制 fallback 到 CPU, 可选
@@ -214,11 +213,11 @@ autocompare:    add.out other: allclose
 >>>
 ```
 
-可以看到，输出包括 CPU 和设备计算结果的 `shape`、`stride`、`dtype` 等信息， 最终结果是CPU和设备的self和out都是allclose的。
+可以看到，输出包括 CPU 和设备计算结果的 `shape`、`stride`、`dtype` 等信息，最终结果是 CPU 和设备的 self 和 out 都是 allclose 的。
 
 ##### 算子精度自动对比功能的设置
 
-算子精度自动对比功能默认不开启，可以设置环境变量`DIPU_AUTOCOMPARE_OPS_LIST`来控制该功能，在开启算子自动对比功能前，必须unset  `DIPU_FORCE_FALLBACK_OPS_LIST`
+算子精度自动对比功能默认不开启，可以设置环境变量`DIPU_AUTOCOMPARE_OPS_LIST`来控制该功能，在开启算子自动对比功能前，必须 unset `DIPU_FORCE_FALLBACK_OPS_LIST`
 
 - 可以通过设置环境变量`DIPU_AUTOCOMPARE_OPS_LIST='.*'`，开启全局的精度对比，这种情况下所有调用的算子都会进行精度对比。
 
@@ -240,7 +239,7 @@ NOTE:
 
 1. 部分算子并不支持自动精度对比功能，可以查看[diopi_functions.yaml](https://github.com/DeepLink-org/deeplink.framework/blob/main/dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml)，其中的`autocompare`配置项为`disable`即不支持自动精度对比功能，同时也可以修改`diopi_functions.yaml`，将某些算子的`autocompare`配置项设置为`disable`来禁用自动对比功能。
 2. `dipu/scripts/autogen_diopi_wrapper/diopi_functions.yaml` 中配置了 `autograd:True` 的算子 (`cross_entropy_loss`、`conv2d`、`dropout`、`dropout_`、`linear`) 暂不支持 *backward* 的精度自动对比。如模型精度对不齐，可根据需要先将这几个算子 fallback 到 CPU 来确定问题。
-3. 对输入参数(self)做检查是确保算子的输入不被意外修改。
+3. 对输入参数 (self) 做检查是确保算子的输入不被意外修改。
 
 #### 抓取算子参数
 

--- a/dipu/scripts/ci/nv/ci_nv_env.sh
+++ b/dipu/scripts/ci/nv/ci_nv_env.sh
@@ -1,7 +1,7 @@
 PLATFORM=/mnt/cache/share/platform
 ENV_NAME=pt2.0_diopi
-export PATH=`python ${PLATFORM}/env/clear_path.py PATH`
-export LD_LIBRARY_PATH=`python ${PLATFORM}/env/clear_path.py LD_LIBRARY_PATH`
+export PATH=$(python ${PLATFORM}/env/clear_path.py PATH)
+export LD_LIBRARY_PATH=$(python ${PLATFORM}/env/clear_path.py LD_LIBRARY_PATH)
 GCC_ROOT=${PLATFORM}/dep/gcc-10.2
 CONDA_ROOT=${PLATFORM}/env/miniconda3.10
 export CC=${GCC_ROOT}/bin/gcc
@@ -10,8 +10,6 @@ export CXX=${GCC_ROOT}/bin/g++
 export CUDA_PATH=${PLATFORM}/dep/cuda11.8-cudnn8.9
 export MPI_ROOT=${PLATFORM}/dep/openmpi-4.0.5-cuda11.8
 export NCCL_ROOT=${PLATFORM}/dep/nccl-2.15.5-cuda11.8
-export GTEST_ROOT=${PLATFORM}/dep/googletest-gcc5.4
-
 
 export LD_LIBRARY_PATH=${CONDA_ROOT}/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${CUDA_PATH}/lib64:${CUDA_PATH}/extras/CUPTI/lib64/:$LD_LIBRARY_PATH
@@ -20,12 +18,9 @@ export LD_LIBRARY_PATH=${PLATFORM}/dep/binutils-2.27/lib:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${NCCL_ROOT}/lib/:$LD_LIBRARY_PATH
 export PIP_CONFIG_FILE=${CONDA_ROOT}/envs/${ENV_NAME}/.pip/pip.conf
 
-export DIOPI_ROOT=$(pwd)/third_party/DIOPI/impl/lib/
-export DIPU_ROOT=$(pwd)/torch_dipu
-export DIOPI_PATH=$(pwd)/third_party/DIOPI/proto
-export DIPU_PATH=${DIPU_ROOT}
+# TODO(wy): do more cleaning and replace $PWD
 export PYTORCH_DIR=${PLATFORM}/dep/DIOPI_pytorch/pytorch2.0_cu118
-export LD_LIBRARY_PATH=$DIPU_ROOT:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$PWD/torch_dipu:$LD_LIBRARY_PATH
 export PYTHONPATH=${PYTORCH_DIR}:${PYTHONPATH}
 export PATH=${GCC_ROOT}/bin:${CONDA_ROOT}/envs/dipu_poc/bin:${CONDA_ROOT}/bin:${PLATFORM}/dep/binutils-2.27/bin:/usr/sbin:${PATH}
 export PYTORCH_DIR=${PLATFORM}/env/miniconda3.8/envs/pt2.0_diopi/pytorch2.0

--- a/dipu/scripts/ci/nv/ci_nv_script.sh
+++ b/dipu/scripts/ci/nv/ci_nv_script.sh
@@ -1,29 +1,41 @@
 # !/bin/bash
 set -eo pipefail
 
+readonly OUTPUT="build"
+
+function clean() {
+    echo "Remove: '$PWD/$OUTPUT'"
+    rm -rf "$OUTPUT"
+}
+
 function build() {
-    path="build"
-    echo "Building DIPU into: '$PWD/$path'"
-    echo " - DIOPI_ROOT=${DIOPI_ROOT}"
+    echo "Building DIPU into: '$PWD/$OUTPUT'"
 
     args=(
         "-DDEVICE=cuda"
         "-DENABLE_COVERAGE=${USE_COVERAGE}"
         "-DCMAKE_BUILD_TYPE=Release"
         "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
-        "$@" )
+        "$@")
 
-    rm -rf "$path"
-    mkdir -p "$path"
-    cmake -B "$path" -S . "${args[@]}" 2>&1 | tee "${path}/cmake_nv.log"
-    cmake --build "$path" --parallel 8 2>&1 | tee "${path}/build.log"
+    mkdir -p "$OUTPUT"
+    cmake -B "$OUTPUT" -S . "${args[@]}" 2>&1 | tee "${OUTPUT}/configure.log"
+    cmake --build "$OUTPUT" --parallel 8 2>&1 | tee "${OUTPUT}/build.log"
 }
 
 case $1 in
-    "build_dipu")
-        build ;;
-    "build_dipu_only")
-        build "-DWITH_DIOPI_LIBRARY=DISABLE" ;;
-    *)
-        echo "[ERROR] Incorrect option: $1" && exit 1 ;;
+"build_dipu")
+    clean
+    build
+    ;;
+"build_dipu_dev")
+    build "${@:2}"
+    ;;
+"build_dipu_only")
+    clean
+    build "-DWITH_DIOPI_LIBRARY=DISABLE"
+    ;;
+*)
+    echo "[ERROR] Incorrect option: $1" && exit 1
+    ;;
 esac


### PR DESCRIPTION
删除了可能不再需要的 DIPU_ROOT 等环境变量，目前搜索了一下只有 DeepLinkExt 还在用这个，但那边应该不会使用 ci 的环境

另外为 @Wrench-Git 添加了一个样例，可以这样构建：

```bash
srun ...... bash scripts/ci/nv/ci_nv_script.sh build_dipu_dev -DDIOPI_TORCH_UNSAFE_BUILDATEN=ON
```