### PR TITLE
feat(dipu): exit->warn when expandable_segments set but not supported

### DIFF
--- a/dipu/tests/python/individual_scripts/test_allocator_conf.py
+++ b/dipu/tests/python/individual_scripts/test_allocator_conf.py
@@ -22,7 +22,10 @@ def test_set_allocator_settings(allocator: str):
         captured_output = captured.getvalue().decode("utf-8")
 
         is_torch_allocator = allocator == "TORCH"
-        failed = "Not using torch allocator, skipping setAllocatorSettings" in captured_output
+        failed = (
+            "Not using torch allocator, skipping setAllocatorSettings"
+            in captured_output
+        )
         assert is_torch_allocator == (not failed)
 
 

--- a/dipu/tests/python/individual_scripts/test_allocator_conf.py
+++ b/dipu/tests/python/individual_scripts/test_allocator_conf.py
@@ -21,13 +21,9 @@ def test_set_allocator_settings(allocator: str):
             torch.cuda.memory._set_allocator_settings("expandable_segments:True")
         captured_output = captured.getvalue().decode("utf-8")
 
-        if allocator == "TORCH":
-            assert captured_output == ""
-        else:
-            assert (
-                "Not using torch allocator, skipping setAllocatorSettings"
-                in captured_output
-            )
+        is_torch_allocator = allocator == "TORCH"
+        failed = "Not using torch allocator, skipping setAllocatorSettings" in captured_output
+        assert is_torch_allocator == (not failed)
 
 
 if __name__ == "__main__":

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingDeviceAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingDeviceAllocator.cpp
@@ -476,6 +476,13 @@ void CachingAllocatorConfig::parseArgs(const char* env) {
           i < config.size() && (config[i] == "True" || config[i] == "False"),
           "Expected a single True/False argument for expandable_segments");
       m_expandable_segments = (config[i] == "True");
+      if (!vendorCreateExpandableSegment) {
+        DIPU_LOGW(
+            "expandable_segments is set to True, but no implementation of "
+            "vendorCreateExpandableSegment is found. Hence ignoring the "
+            "setting.");
+        m_expandable_segments = false;
+      }
     } else {
       TORCH_CHECK(false, "Unrecognized CachingAllocator option: ", config[i]);
     }

--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingDeviceAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingDeviceAllocator.cpp
@@ -40,7 +40,9 @@
 // Our changes:
 //    1. use dipu runtime api to replace CUDA API.
 //    2. make ExpandableSegment to an interface class, vendor should implement
-//    it if want to support expandable segments.
+//    it if want to support expandable segments. If
+//    vendorCreateExpandableSegment is not implemented, the allocator will never
+//    use expandable segments.
 //    3. remove EventPool class, DIPU already supports it.
 // ----------------------------------------------------------------------------
 namespace dipu::allocator {
@@ -476,7 +478,7 @@ void CachingAllocatorConfig::parseArgs(const char* env) {
           i < config.size() && (config[i] == "True" || config[i] == "False"),
           "Expected a single True/False argument for expandable_segments");
       m_expandable_segments = (config[i] == "True");
-      if (!vendorCreateExpandableSegment) {
+      if (m_expandable_segments && !vendorCreateExpandableSegment) {
         DIPU_LOGW(
             "expandable_segments is set to True, but no implementation of "
             "vendorCreateExpandableSegment is found. Hence ignoring the "


### PR DESCRIPTION
以前会直接挂，现在强制 false。

用于 internevo 这种在代码里强设 expandable_segments 的情况。