### PR TITLE
fix camb copy_D2otherD bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
     needs: [Build-Camb]
     runs-on: github-poc-ci
     env:
-      MLU_REQUESTS: 1
+      MLU_REQUESTS: 4 
     steps:
       - name: Run-test
         run: |
@@ -210,7 +210,7 @@ jobs:
     needs: [Build-Camb-Pt211]
     runs-on: github-poc-ci
     env:
-      MLU_REQUESTS: 1
+      MLU_REQUESTS: 4
     steps:
       - name: Run-test
         run: |

--- a/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/ops/DIPUCopy.hpp
@@ -217,9 +217,10 @@ inline void doSrcStreamWaitDstStream(const CopyParamsInfo& info,
   DIPUEvent dstEvent;
   dstEvent.record(dipu::getCurrentDIPUStream(info.dstDevice_));
   dstGuard.set_index(info.srcDevice_);
-  dstEvent.wait(info.curStream_);
   if (block_cpu) {
     dstEvent.synchronize();
+  } else {
+    dstEvent.wait(info.curStream_);
   }
 }
 
@@ -228,9 +229,10 @@ inline void doDstStreamWaitSrcStream(const CopyParamsInfo& info,
   DIPUEvent srcEvent;
   srcEvent.record(info.curStream_);
   DIPUGuard dstGuard(info.dstDevice_);
-  srcEvent.wait(dipu::getCurrentDIPUStream(info.dstDevice_));
   if (block_cpu) {
     srcEvent.synchronize();
+  } else {
+    srcEvent.wait(dipu::getCurrentDIPUStream(info.dstDevice_));
   }
 }
 


### PR DESCRIPTION
寒武纪runtime不支持stream等待另一张卡上的event, cnrtQueueWaitNotifier 返回100050(This indicates that the feature is not supported now),因此我们这里使用同步级别更高的syncStream来代替stramWaitEvent。
由于测试用例中有些测例（多卡间内存拷贝至少需要两张卡，通信相关测例需要四张卡）需要多张卡，在ci中运行测例时，分配多张卡资源,避免有些测例被跳过

Cambrian runtime does not support stream waiting for events on another card, cnrtQueueWaitNotifier returns 100050 (This indicates that the feature is not supported now), so we use syncStream with a higher synchronization level instead of stramWaitEvent.

Because some test cases in the test case require multiple cards (memory copy between multiple cards requires at least two cards, and communication-related test cases require four cards), when running the test cases in CI, allocate multiple card resources to avoid some test cases being skipped.

![截屏2024-07-08 下午9 11 05](https://github.com/DeepLink-org/deeplink.framework/assets/109069909/956fde28-19e1-45dc-a01d-2a0ca9eaff31)
![截屏2024-07-08 下午9 15 07](https://github.com/DeepLink-org/deeplink.framework/assets/109069909/b0a7303b-6ad2-4102-a7b9-f1ad381e4992)
![WeChatWorkScreenshot_d893566f-0518-4cb2-aa9c-1d81be05414b](https://github.com/DeepLink-org/deeplink.framework/assets/109069909/c3e50d15-5004-45f2-a36b-f695bb92841e)
