### PR TITLE
enable multi-cards relate test case

### DIFF
--- a/.github/workflows/_runs-on-nv-step2.yml
+++ b/.github/workflows/_runs-on-nv-step2.yml
@@ -56,7 +56,7 @@ jobs:
             export USE_COVERAGE=ON
             cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && cd Build-Cuda/dipu
             source ${ENV_PATH}/dipu_env
-            srun --job-name=${GITHUB_RUN_NUMBER}_${GITHUB_JOB} --partition=${CUDA_PARTATION} --gres=gpu:1 --cpus-per-task=5 --mem=16G --time=70 sh tests/run_nv_tests.sh
+            srun --job-name=${GITHUB_RUN_NUMBER}_${GITHUB_JOB} --partition=${CUDA_PARTATION} --gres=gpu:2 --cpus-per-task=5 --mem=16G --time=70 sh tests/run_nv_tests.sh
             if [ "${ALL_COVERAGE}" = "ON" ]; then
             bash /mnt/cache/share/platform/dep/sonar/coverage_DIPU_nv.sh ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/Build-Cuda ${GITHUB_RUN_NUMBER} || echo "get coverage fail"
             fi
@@ -224,7 +224,7 @@ jobs:
             set -ex
             cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && cd Build-Cuda-Latest-Target/dipu
             source ${ENV_PATH}/dipu_env
-            srun --job-name=${GITHUB_RUN_NUMBER}_${GITHUB_JOB} --partition=${CUDA_PARTATION} --gres=gpu:4 --cpus-per-task=5 --mem=16G --time=60 sh tests/run_nv_tests.sh && cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf Build-Cuda-Latest-Target \
+            srun --job-name=${GITHUB_RUN_NUMBER}_${GITHUB_JOB} --partition=${CUDA_PARTATION} --gres=gpu:2 --cpus-per-task=5 --mem=16G --time=60 sh tests/run_nv_tests.sh && cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf Build-Cuda-Latest-Target \
             || ( cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf Build-Cuda-Latest-Target && exit 1 )
             """
           fi
@@ -279,7 +279,7 @@ jobs:
             set -ex
             cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/Build-Cuda-Pt211/dipu
             source ${ENV_PATH}/dipu_env 2.1.1
-            srun --job-name=${GITHUB_RUN_NUMBER}_${GITHUB_JOB} --partition=${CUDA_PARTATION} --gres=gpu:4 --cpus-per-task=5 bash tests/run_nv_tests.sh \
+            srun --job-name=${GITHUB_RUN_NUMBER}_${GITHUB_JOB} --partition=${CUDA_PARTATION} --gres=gpu:2 --cpus-per-task=5 bash tests/run_nv_tests.sh \
             || ( cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf Build-Cuda-Pt211 && exit 1 )
             """
           fi

--- a/.github/workflows/_runs-on-nv-step2.yml
+++ b/.github/workflows/_runs-on-nv-step2.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           if [[ "${GETRUNNER}" == *sco* ]];then
             set -e
-            srun --job-name=${GITHUB_JOB} bash -c "export USE_COVERAGE=ON && cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/Build-Cuda/dipu \
+            srun --job-name=need_two_gpus bash -c "export USE_COVERAGE=ON && cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/Build-Cuda/dipu \
             && source ${ENV_PATH}/dipu_env  \
             && bash tests/run_nv_tests.sh"
             if [ "${ALL_COVERAGE}" = "ON" ]; then
@@ -216,7 +216,7 @@ jobs:
         run: |
           if [[ "${GETRUNNER}" == *sco* ]];then
             set -e
-            srun --job-name=${GITHUB_JOB} bash -c "cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/Build-Cuda-Latest-Target/dipu \
+            srun --job-name=need_two_gpus bash -c "cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/Build-Cuda-Latest-Target/dipu \
             && source ${ENV_PATH}/dipu_env  \
             && bash tests/run_nv_tests.sh" && cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf Build-Cuda-Latest-Target
           else
@@ -271,7 +271,7 @@ jobs:
         run: |
           if [[ "${GETRUNNER}" == *sco* ]];then
             set -e
-            srun --job-name=${GITHUB_JOB} bash -c "cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/Build-Cuda-Pt211/dipu \
+            srun --job-name=need_two_gpus bash -c "cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/Build-Cuda-Pt211/dipu \
             && source ${ENV_PATH}/dipu_env 2.1.1 \
             && bash tests/run_nv_tests.sh" && cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf Build-Cuda-Pt211
           else

--- a/.github/workflows/_runs-on-nv-step2.yml
+++ b/.github/workflows/_runs-on-nv-step2.yml
@@ -224,7 +224,7 @@ jobs:
             set -ex
             cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && cd Build-Cuda-Latest-Target/dipu
             source ${ENV_PATH}/dipu_env
-            srun --job-name=${GITHUB_RUN_NUMBER}_${GITHUB_JOB} --partition=${CUDA_PARTATION} --gres=gpu:1 --cpus-per-task=5 --mem=16G --time=60 sh tests/run_nv_tests.sh && cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf Build-Cuda-Latest-Target \
+            srun --job-name=${GITHUB_RUN_NUMBER}_${GITHUB_JOB} --partition=${CUDA_PARTATION} --gres=gpu:4 --cpus-per-task=5 --mem=16G --time=60 sh tests/run_nv_tests.sh && cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf Build-Cuda-Latest-Target \
             || ( cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf Build-Cuda-Latest-Target && exit 1 )
             """
           fi
@@ -279,7 +279,7 @@ jobs:
             set -ex
             cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/Build-Cuda-Pt211/dipu
             source ${ENV_PATH}/dipu_env 2.1.1
-            srun --job-name=${GITHUB_RUN_NUMBER}_${GITHUB_JOB} --partition=${CUDA_PARTATION} --gres=gpu:1 --cpus-per-task=5 bash tests/run_nv_tests.sh \
+            srun --job-name=${GITHUB_RUN_NUMBER}_${GITHUB_JOB} --partition=${CUDA_PARTATION} --gres=gpu:4 --cpus-per-task=5 bash tests/run_nv_tests.sh \
             || ( cd ${DEEPLINK_PATH}/${GITHUB_RUN_NUMBER}/ && rm -rf Build-Cuda-Pt211 && exit 1 )
             """
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
           TAG=${GITHUB_REF#refs/tags/} # Extract the tag name
           echo $TAG
           bash /mnt/cache/share/platform/dep/Deploy_DIPU_trigger.sh "$TAG"
-          
+
   Build-Camb:
     name: Build-dipu-camb
     needs: [Runs-On-Nv-Step1]
@@ -307,7 +307,7 @@ jobs:
     needs: [Build-Camb-Latest-Target]
     runs-on: github-poc-ci
     env:
-      MLU_REQUESTS: 1
+      MLU_REQUESTS: 4
     steps:
       - name: Run-test
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
     needs: [Build-Camb]
     runs-on: github-poc-ci
     env:
-      MLU_REQUESTS: 1
+      MLU_REQUESTS: 4 
     steps:
       - name: Run-test
         run: |
@@ -210,7 +210,7 @@ jobs:
     needs: [Build-Camb-Pt211]
     runs-on: github-poc-ci
     env:
-      MLU_REQUESTS: 1
+      MLU_REQUESTS: 4
     steps:
       - name: Run-test
         run: |

--- a/dipu/tests/python/individual_scripts/test_rt_ddp.py
+++ b/dipu/tests/python/individual_scripts/test_rt_ddp.py
@@ -581,7 +581,7 @@ if __name__ == "__main__":
 
     port = random.randint(10000, 60000)
 
-    world_size = 1
+    world_size = n_gpus
     run_demo(demo_basic_ddp, world_size, port)
     run_demo(demo_allreduce, world_size, port)
     run_demo(demo_allgather, world_size, port)

--- a/dipu/tests/python/individual_scripts/test_rt_ddp.py
+++ b/dipu/tests/python/individual_scripts/test_rt_ddp.py
@@ -3,6 +3,7 @@ import torch
 import random
 from torch import nn
 import os
+import subprocess
 import torch
 import torch.distributed as dist
 import torch.nn as nn
@@ -140,7 +141,8 @@ def demo_allreduce(rank, world_size, port):
             expected_tensor = torch.tensor([True, False, True], dtype=torch.bool).to(
                 dev1
             )
-        assert torch.allclose(te_result, expected_tensor)
+        print(f"te_result:{te_result}, expected_tensor: {expected_tensor}")
+        assert torch.allclose(te_result.cpu(), expected_tensor.cpu())
 
     # byte
     for op in [dist.reduce_op.SUM, dist.reduce_op.MAX, dist.reduce_op.MIN]:
@@ -217,13 +219,13 @@ def demo_bcast(rank, world_size, port):
     src1 = torch.ones((2, 4)).to(rank)
     dst = torch.empty((2, 4)).to(rank)
     # print(dst)
-    for i in range(1, 3):
+    for i in range(world_size):
         if rank == 0:
             dist.broadcast(src1, 0)
         else:
             dist.broadcast(dst, 0)
-    assert torch.allclose(src1, dst)
-    print(dst)
+    if rank != 0:
+        assert torch.allclose(src1, dst), str(dst)
     cleanup()
 
 
@@ -238,7 +240,7 @@ def demo_gather(rank, world_size, port):
         gather_list = [torch.empty((2, 4)).to(rank) for _ in range(world_size)]
     else:
         gather_list = None
-    for i in range(1, 3):
+    for i in range(world_size):
         dist.gather(src, gather_list, dst=root_rank)
     if rank == root_rank:
         for i in range(world_size):
@@ -319,10 +321,11 @@ def demo_reducescatter(rank, world_size, port):
 
     dst = torch.zeros((2, 4)).to(rank)
     # print(dst)
-    for i in range(1, 3):
+    for i in range(world_size):
         dist.reduce_scatter(dst, srcs, op=dist.reduce_op.SUM)
-
-    assert torch.allclose(srcs[0], dst)
+    print(f"src:{srcs[0]}")
+    print(f"dst:{dst}")
+    assert torch.allclose(srcs[0].cpu() * world_size, dst.cpu())
     print(dst)
     cleanup()
 
@@ -334,9 +337,9 @@ def demo_reducescatter_base(rank, world_size, port):
 
     src1 = torch.ones((world_size * 2, 4)).to(rank)
     dst = torch.zeros((2, 4)).to(rank)
-    for i in range(1, 3):
+    for i in range(world_size):
         dist.reduce_scatter_tensor(dst, src1, op=dist.reduce_op.SUM)
-    assert torch.allclose(torch.ones((2, 4)), dst.cpu())
+    assert torch.allclose(torch.ones((2, 4)) * world_size, dst.cpu())
     print(dst)
     cleanup()
 
@@ -443,17 +446,18 @@ def demo_alltoall(rank, world_size, port):
 
 
 def demo_model_parallel(rank, world_size, port):
+    import torch_dipu
+
     print(f"Running DDP with model parallel example on rank {rank}.")
     backend = "nccl"
     dev1 = rank
 
     # debugat(rank)
-    setup(backend, rank, world_size)
+    setup(rank, world_size, port)
 
     # setup mp_model and devices for this process
-    dev0 = (rank * 2) % world_size
-    dev1 = (rank * 2 + 1) % world_size
-    mp_model = ToyMpModel(dev0, dev1)
+    dev0 = rank
+    mp_model = ToyModel().to(dev0)
     ddp_mp_model = DDP(mp_model)
 
     loss_fn = nn.MSELoss()
@@ -461,8 +465,8 @@ def demo_model_parallel(rank, world_size, port):
 
     optimizer.zero_grad()
     # outputs will be on dev1
-    outputs = ddp_mp_model(torch.randn(20, 10))
-    labels = torch.randn(20, 5).to(dev1)
+    outputs = ddp_mp_model(torch.randn(20, 10).to(dev0))
+    labels = torch.randn(20, 5).to(dev0)
     loss_fn(outputs, labels).backward()
     optimizer.step()
 
@@ -500,12 +504,12 @@ def demo_allgather_gloo(rank, world_size, port):
     cleanup()
 
 
-def test_special_group_stuck(rank, world_size):
+def test_special_group_stuck(rank, world_size, port):
     import torch_dipu
 
     print(f"test special group stuck on rank {rank} ")
 
-    setup(rank, world_size)
+    setup(rank, world_size, port)
 
     # ranks check require len(ranks) <= world_size
     if world_size >= 2:
@@ -519,9 +523,11 @@ def test_special_group_stuck(rank, world_size):
     cleanup()
 
 
-def test_new_group(rank, world_size):
+def test_new_group(rank, world_size, port):
+    import torch_dipu
+
     print(f"test group on rank {rank} ws: {world_size}")
-    setup(rank, world_size)
+    setup(rank, world_size, port)
     for op in [
         dist.reduce_op.SUM,
     ]:
@@ -577,11 +583,17 @@ def test_get_comm_name(rank, world_size, port):
 
 
 if __name__ == "__main__":
-    n_gpus = torch.cuda.device_count()
-
     port = random.randint(10000, 60000)
-
-    world_size = n_gpus
+    # get device_count without "import torch_dipu"
+    sub_process = subprocess.run(
+        [
+            "python",
+            "-c",
+            "import torch;import torch_dipu;exit(torch.cuda.device_count())",
+        ]
+    )
+    world_size = sub_process.returncode
+    print(f"world_size: {world_size}")
     run_demo(demo_basic_ddp, world_size, port)
     run_demo(demo_allreduce, world_size, port)
     run_demo(demo_allgather, world_size, port)
@@ -599,12 +611,14 @@ if __name__ == "__main__":
     run_demo(test_get_comm_name, world_size, port)
 
     # need 2 card to run
-    # run_demo(demo_p2p, world_size, port)
-    # run_demo(demo_bcast, world_size, port)
+    if world_size >= 2:
+        run_demo(demo_p2p, world_size, port)
+        run_demo(demo_bcast, world_size, port)
 
-    # run_demo(demo_model_parallel, world_size)
+        run_demo(demo_model_parallel, world_size, port)
 
-    # run_demo(test_special_group_stuck, world_size)
+        run_demo(test_special_group_stuck, world_size, port)
 
     # need 4 card to run
-    # run_demo(test_new_group, world_size)
+    if world_size >= 4:
+        run_demo(test_new_group, world_size, port)

--- a/dipu/tests/python/unittests/test_copy.py
+++ b/dipu/tests/python/unittests/test_copy.py
@@ -2,7 +2,12 @@
 import itertools
 import torch
 import torch_dipu
-from torch_dipu.testing._internal.common_utils import TestCase, run_tests, skipOn
+from torch_dipu.testing._internal.common_utils import (
+    TestCase,
+    run_tests,
+    skipOn,
+    skipIfDevcieCountLessThan,
+)
 
 
 class TestCopy(TestCase):
@@ -79,6 +84,7 @@ class TestCopy(TestCase):
         dst1.copy_(src)
         self.assertEqual(dst1.cpu(), src.cpu())
 
+    @skipIfDevcieCountLessThan(2)
     def test_d2d_peer_copy_(self):
         if torch.cuda.device_count() < 2:
             assert (
@@ -98,6 +104,7 @@ class TestCopy(TestCase):
         self.assertEqual(dst.device.index, 1)
         self.assertEqual(src.device.index, 0)
 
+    @skipIfDevcieCountLessThan(2)
     def test_d2d_peer_copy_no_contiguous(self):
         if torch.cuda.device_count() < 2:
             assert (

--- a/dipu/tests/python/unittests/test_copy.py
+++ b/dipu/tests/python/unittests/test_copy.py
@@ -81,7 +81,9 @@ class TestCopy(TestCase):
 
     def test_d2d_peer_copy_(self):
         if torch.cuda.device_count() < 2:
-            return
+            assert (
+                False
+            ), "At least two cards are required for copying between multiple cards"
         dst = torch.rand((6400, 4000), device="cuda:0")
         src = torch.rand((6400, 4000), device="cuda:1")
         dst.copy_(src)
@@ -98,7 +100,9 @@ class TestCopy(TestCase):
 
     def test_d2d_peer_copy_no_contiguous(self):
         if torch.cuda.device_count() < 2:
-            return
+            assert (
+                False
+            ), "At least two cards are required for copying between multiple cards"
         src = torch.rand((6400, 9900), device="cuda:1")[::2, ::3]
         dst = src.to("cuda:0")
         self.assertEqual(dst.cpu(), src.cpu())

--- a/dipu/tests/run_ascend_tests.sh
+++ b/dipu/tests/run_ascend_tests.sh
@@ -7,6 +7,7 @@ function run_dipu_tests {
     # TODO: Add PyTorch tests
     # run_test tests/test_ops/archived/test_tensor_add.py
     python tests/python/individual_scripts/test_rt_ddp.py
+    python tests/python/unittests/test_copy.py
 }
 
 if [ "$LOGFILE" != "" ]; then

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -54,7 +54,7 @@ set(GENERATED_KERNELS "${CMAKE_CURRENT_SOURCE_DIR}/aten/ops/AutoGenedKernels.cpp
 set(GENERATED_KERNELS_VENDOR "${PROJECT_SOURCE_DIR}/third_party/DIOPI/impl/${UsedVendor}/convert_config.yaml")
 set(GENERATED_KERNELS_SCRIPT "${AUTOGEN_DIOPI_WRAPPER_DIR}/autogen_diopi_wrapper.py")
 set(GENERATED_KERNELS_CONFIG "${AUTOGEN_DIOPI_WRAPPER_DIR}/diopi_functions.yaml")
-set(DEVICE_GUARD_FREE_VENDOR "") # vensors that do not need to device guard need to be added to this list.
+set(DEVICE_GUARD_FREE_VENDOR "") # Vendors that do not require Device Guard should be included in this list.
 if (${UsedVendor} IN_LIST DEVICE_GUARD_FREE_VENDOR)
   set(GENERATE_DEVICE_GUARD False)
 else()

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -54,7 +54,7 @@ set(GENERATED_KERNELS "${CMAKE_CURRENT_SOURCE_DIR}/aten/ops/AutoGenedKernels.cpp
 set(GENERATED_KERNELS_VENDOR "${PROJECT_SOURCE_DIR}/third_party/DIOPI/impl/${UsedVendor}/convert_config.yaml")
 set(GENERATED_KERNELS_SCRIPT "${AUTOGEN_DIOPI_WRAPPER_DIR}/autogen_diopi_wrapper.py")
 set(GENERATED_KERNELS_CONFIG "${AUTOGEN_DIOPI_WRAPPER_DIR}/diopi_functions.yaml")
-set(DEVICE_GUARD_FREE_VENDOR cuda) # vensors that do not need to device guard need to be added to this list.
+#set(DEVICE_GUARD_FREE_VENDOR cuda) # vensors that do not need to device guard need to be added to this list.
 if (${UsedVendor} IN_LIST DEVICE_GUARD_FREE_VENDOR)
   set(GENERATE_DEVICE_GUARD False)
 else()

--- a/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
+++ b/dipu/torch_dipu/csrc_dipu/CMakeLists.txt
@@ -54,7 +54,7 @@ set(GENERATED_KERNELS "${CMAKE_CURRENT_SOURCE_DIR}/aten/ops/AutoGenedKernels.cpp
 set(GENERATED_KERNELS_VENDOR "${PROJECT_SOURCE_DIR}/third_party/DIOPI/impl/${UsedVendor}/convert_config.yaml")
 set(GENERATED_KERNELS_SCRIPT "${AUTOGEN_DIOPI_WRAPPER_DIR}/autogen_diopi_wrapper.py")
 set(GENERATED_KERNELS_CONFIG "${AUTOGEN_DIOPI_WRAPPER_DIR}/diopi_functions.yaml")
-#set(DEVICE_GUARD_FREE_VENDOR cuda) # vensors that do not need to device guard need to be added to this list.
+set(DEVICE_GUARD_FREE_VENDOR "") # vensors that do not need to device guard need to be added to this list.
 if (${UsedVendor} IN_LIST DEVICE_GUARD_FREE_VENDOR)
   set(GENERATE_DEVICE_GUARD False)
 else()

--- a/dipu/torch_dipu/testing/_internal/common_utils.py
+++ b/dipu/torch_dipu/testing/_internal/common_utils.py
@@ -69,6 +69,13 @@ def skipOn(vendor: str, reason: str):
     return unittest.skipIf(torch_dipu.dipu.vendor_type == vendor, reason)
 
 
+def skipIfDevcieCountLessThan(number_of_devices_required):
+    return unittest.skipIf(
+        torch_dipu.dipu.device_count() < number_of_devices_required,
+        f"available device are less than {number_of_devices_required}",
+    )
+
+
 @overload
 def onlyOn(vendor: str): ...
 


### PR DESCRIPTION
1. 修复cuda 多卡测试时出现的问题
2. ci中部分测试时分配多卡资源来进行多卡测试
<img width="323" alt="企业微信截图_17205974425830" src="https://github.com/DeepLink-org/deeplink.framework/assets/109069909/3534b47c-60e2-4ab8-a5a3-a30777c6f70c">
need_two_gpus 是一个和ci 机器约定好的标识符，不是随便起的名，要改得两边同时改。目前nv的ci是跑在sensecore上的。

![截屏2024-07-11 下午2 30 10](https://github.com/DeepLink-org/deeplink.framework/assets/109069909/0e78792c-20c1-4752-a75b-3a70a6c8cf2f)
