### PR TITLE
[DIPU]fix torch allocator core dump when process exit

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingDeviceAllocator.cpp
+++ b/dipu/torch_dipu/csrc_dipu/runtime/core/allocator/DIPUCachingDeviceAllocator.cpp
@@ -2020,10 +2020,10 @@ class NativeCachingAllocator : public DeviceAllocator {
 };
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-NativeCachingAllocator native_caching_allocator;
-REGISTER_ALLOCATOR(dipu::DIPU_DEVICE_TYPE, &native_caching_allocator);
+NativeCachingAllocator* native_caching_allocator = new NativeCachingAllocator();
+REGISTER_ALLOCATOR(dipu::DIPU_DEVICE_TYPE, native_caching_allocator);
 
-void local_raw_delete(void* ptr) { native_caching_allocator.free(ptr); }
+void local_raw_delete(void* ptr) { native_caching_allocator->free(ptr); }
 
 // General caching allocator utilities
 void setAllocatorSettings(const std::string& env) {
@@ -2058,7 +2058,7 @@ std::string format_size(uint64_t size) {
 
 struct BackendStaticInitializer {
   BackendStaticInitializer() {
-    allocator.store(&native_caching_allocator);
+    allocator.store(native_caching_allocator);
     init(devproxy::getDeviceCount());
   }
 };


### PR DESCRIPTION
NativeCachingAllocator提前析构，导致退出的时候出现析构core dump。将NativeCachingAllocator放在堆上，进程退出的时候由操作系统回收，避免析构顺序导致的问题。