### PR TITLE
[Feature] Align ascend profiler with torch profiler

### DIFF
--- a/dipu/tests/python/unittests/test_profiler_vendor.py
+++ b/dipu/tests/python/unittests/test_profiler_vendor.py
@@ -94,6 +94,52 @@ class TestProfiler(TestCase):
         self.assertTrue(check_string_in_directory(export_path, "aten::mul"))
         self.assertTrue(check_string_in_directory(export_path, "[memory]"))
         self.assertTrue(check_string_in_directory(export_path, "[Input Dims]"))
+        self.assertTrue(check_string_in_directory(export_path, "CANN"))
+        self.assertTrue(check_string_in_directory(export_path, "Ascend Hardware"))
+
+        self.assertFalse(check_string_in_directory(export_path, "Node@launch"))
+
+    @onlyOn("NPU")
+    def test_profiler_ascend_schedule(self):
+        def fn(x):
+            y = torch.nn.functional.softmax(x, -1)
+            y = y * 5
+            y = torch.relu(y)
+            return y
+
+        def export_step_chrome_trace(prof):
+            export_path = f"./tmp/test_profiler_ascend_schedule_{prof.step_num}.json"
+            prof.export_chrome_trace(export_path)
+
+            self.assertTrue(
+                check_string_in_directory(export_path, "test_profiler_vendor.py")
+            )
+            self.assertTrue(
+                check_string_in_directory(export_path, "AscendCL@aclnnSoftmax")
+            )
+            self.assertTrue(check_string_in_directory(export_path, "aten::mul"))
+            self.assertTrue(check_string_in_directory(export_path, "[memory]"))
+            self.assertTrue(check_string_in_directory(export_path, "[Input Dims]"))
+            self.assertTrue(check_string_in_directory(export_path, "ProfilerStep"))
+            self.assertTrue(check_string_in_directory(export_path, "CANN"))
+            self.assertTrue(check_string_in_directory(export_path, "Ascend Hardware"))
+
+            self.assertFalse(check_string_in_directory(export_path, "Node@launch"))
+
+        input = torch.randn(2, 3).cuda()
+        with profile(
+            activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+            profile_memory=True,
+            record_shapes=True,
+            with_modules=True,
+            with_stack=True,
+            schedule=torch.profiler.schedule(wait=2, warmup=2, active=2, repeat=2),
+            on_trace_ready=export_step_chrome_trace,
+        ) as prof:
+            for _ in range(12):
+                y = fn(input)
+                y = y + y
+                prof.step()
 
     @onlyOn("CUDA")
     def test_profiler_cuda(self):

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.cpp
@@ -107,10 +107,10 @@ int32_t AscendDeviceActivity::processActivities(
   // after test, this is more precise and less stable than calculate at startTrace() and compare with start_info
   // clang-format on
 
-  const int s_to_ns_factor = 1000000000;
-  auto time_x = tx.tv_sec * s_to_ns_factor + tx.tv_nsec;
-  auto monotonic_raw = ts.tv_sec * s_to_ns_factor + ts.tv_nsec;
-  auto time_y = ty.tv_sec * s_to_ns_factor + ty.tv_nsec;
+  const int S_TO_NS_FACTOR = 1000000000;
+  auto time_x = tx.tv_sec * S_TO_NS_FACTOR + tx.tv_nsec;
+  auto monotonic_raw = ts.tv_sec * S_TO_NS_FACTOR + ts.tv_nsec;
+  auto time_y = ty.tv_sec * S_TO_NS_FACTOR + ty.tv_nsec;
 
   int64_t diff = (time_x >> 1) + (time_y >> 1) - monotonic_raw;
 
@@ -132,7 +132,9 @@ int32_t AscendDeviceActivity::processActivities(
   if (last_dump_path_.compare(0, temp_path_prefix.size(), temp_path_prefix) ==
       0) {
     if (remove_temp_dump_path_(last_dump_path_) == false) {
-      DIPU_LOGW("remove temp file failed, may need to remove manually");
+      DIPU_LOGW(
+          "remove ascend profiler temp file failed, may need to remove "
+          "manually");
     }
   }
 

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.cpp
@@ -90,19 +90,6 @@ bool AscendDeviceActivity::remove_temp_dump_path_(const std::string& path) {
   return rmdir(path.c_str()) == 0;
 }
 
-char* AscendDeviceActivity::generate_temp_dump_path_() {
-  struct stat st;
-  if (stat("./tmp", &st) == -1) {
-    mkdir("./tmp", 0777);
-  }
-  if (stat("./tmp/aclprof", &st) == -1) {
-    mkdir("./tmp/aclprof", 0777);
-  }
-
-  char dump_path_template[] = "./tmp/aclprof/aclprofXXXXXX";
-  return mkdtemp(dump_path_template);
-}
-
 int32_t AscendDeviceActivity::processActivities(
     libkineto::ActivityLogger& logger,
     std::function<const libkineto::ITraceActivity*(int32_t)> linked_activity,
@@ -152,9 +139,18 @@ void AscendDeviceActivity::startTrace(
 
   last_dump_path_ = current_dump_path_;
 
-  char* dump_path_cstring = generate_temp_dump_path_();
+  struct stat st;
+  if (stat("./tmp", &st) == -1) {
+    mkdir("./tmp", 0777);
+  }
+  if (stat("./tmp/aclprof", &st) == -1) {
+    mkdir("./tmp/aclprof", 0777);
+  }
 
-  if (dump_path_cstring != nullptr && strlen(dump_path_cstring) != 0) {
+  char dump_path_template[] = "./tmp/aclprof/aclprofXXXXXX";
+  char* dump_path_cstring = mkdtemp(dump_path_template);
+
+  if (dump_path_cstring != nullptr) {
     current_dump_path_ = dump_path_cstring;
   } else {
     DIPU_LOGE(

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.cpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2023, DeepLink.
+#include "AscendDeviceActivity.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <cstdio>
+#include <output_base.h>
+#include <time_since_epoch.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include <sys/stat.h>
+
+#include <c10/util/Exception.h>
+
+#include "csrc_dipu/utils/Log.h"
+
+namespace dipu {
+
+static const uint64_t kNpuEvents = 431;
+static const uint64_t kAicoreMetrics = 1;
+
+using libkineto::GenericTraceActivity;
+
+AscendDeviceActivity::AscendDeviceActivity() {}
+
+AscendDeviceActivity& AscendDeviceActivity::instance() {
+  static AscendDeviceActivity instance;
+  return instance;
+}
+
+// override pure virtual function, do nothing
+void AscendDeviceActivity::pushCorrelationID(
+    uint64_t id, DeviceActivityInterface::CorrelationFlowType type) {}
+
+// override pure virtual function, do nothing
+void AscendDeviceActivity::popCorrelationID(
+    DeviceActivityInterface::CorrelationFlowType type) {}
+
+// override pure virtual function, do nothing
+void AscendDeviceActivity::enableActivities(
+    const std::set<libkineto::ActivityType>& selected_activities) {}
+
+// override pure virtual function, do nothing
+void AscendDeviceActivity::disableActivities(
+    const std::set<libkineto::ActivityType>& selected_activities) {}
+
+// override pure virtual function, do nothing
+void AscendDeviceActivity::clearActivities() {}
+
+int32_t AscendDeviceActivity::processActivities(
+    libkineto::ActivityLogger& logger,
+    std::function<const libkineto::ITraceActivity*(int32_t)> linked_activity,
+    int64_t start_time, int64_t end_time) {
+
+  // 传递USER_ANNOTAION activity标识dump路径
+  GenericTraceActivity tmp_path;
+  tmp_path.activityName = "random_temp_dir:" + current_dump_path_;
+  tmp_path.activityType = libkineto::ActivityType::USER_ANNOTATION;
+  tmp_path.startTime = start_time;
+  tmp_path.endTime = end_time;
+  logger.handleGenericActivity(tmp_path);
+
+  std::string temp_path_prefix = "/tmp/aclprof";
+  if (last_dump_path_.compare(0, temp_path_prefix.size(), temp_path_prefix) == 0) {
+    // TODO 删除不再使用的last_dump_path_
+  }
+
+  return 0;
+}
+
+void AscendDeviceActivity::startTrace(
+    const std::set<libkineto::ActivityType>& selected_activities) {
+  if (enable_) {
+    DIPU_LOGW("ascend profiler has already enabled");
+    return;
+  }
+  enable_ = true;
+
+  last_dump_path_ = current_dump_path_;
+
+  // 创建随机临时路径
+  struct stat st = {0};
+  if (stat("/tmp/aclprof", &st) == -1) {
+    mkdir("/tmp/aclprof", 0777);
+  }
+  char dump_path_template[] = "/tmp/aclprof/aclprofXXXXXX";
+  char* dump_path_cstring = mkdtemp(dump_path_template);
+  if (dump_path_cstring != nullptr) {
+    current_dump_path_ = (std::string)dump_path_cstring;
+  } else {
+    DIPU_LOGE("aclprof random dump path generate failed, the export results may be incorrect");
+    current_dump_path_ = "/tmp/aclprof/aclprof_error";
+  }
+
+  DIPU_CALLACLRT(aclprofInit(current_dump_path_.c_str(), current_dump_path_.size()));
+  DIPU_CALLACLRT(aclrtSynchronizeDevice());
+
+  int32_t device_index = 0;
+  DIPU_CALLACLRT(aclrtGetDevice(&device_index));
+
+  std::array<uint32_t, 1> device_ids = {static_cast<uint32_t>(device_index)};
+  aclprofAicoreEvents* events = nullptr;
+  config_ = aclprofCreateConfig(
+      device_ids.data(), device_ids.size(),
+      static_cast<aclprofAicoreMetrics>(kAicoreMetrics), events, kNpuEvents);
+  TORCH_CHECK(config_ != nullptr,
+              "aclprofCreateConfig fail, device_index = ", device_index,
+              "npu_event = ", kNpuEvents, "aicore_metrics = ", kAicoreMetrics);
+
+  DIPU_CALLACLRT(aclprofStart(config_));
+}
+
+void AscendDeviceActivity::stopTrace(
+    const std::set<libkineto::ActivityType>& selected_activities) {
+  if (!enable_) {
+    DIPU_LOGW("ascend profiler has already disabled");
+    return;
+  }
+
+  DIPU_CALLACLRT(aclrtSynchronizeDevice());
+  DIPU_CALLACLRT(aclprofStop(config_));
+  DIPU_CALLACLRT(aclprofFinalize());
+
+  enable_ = false;
+}
+
+
+// override pure virtual function, do nothing
+void AscendDeviceActivity::teardownContext() {}
+
+// override pure virtual function, do nothing
+void AscendDeviceActivity::setMaxBufferSize(int32_t size) {}
+
+// NOLINTNEXTLINE(cppcoreguidelines-interfaces-global-init)
+const static int32_t Ascend_device_activity_init = []() {
+  const char* env = std::getenv("FORCE_USE_DIPU_PROFILER");
+  if ((env == nullptr) || (strncmp(env, "false", strlen("false")) == 0) ||
+      (strncmp(env, "False", strlen("False")) == 0)) {
+    libkineto::device_activity_singleton = &AscendDeviceActivity::instance();
+    return 1;
+  }
+  return 0;
+}();
+
+}  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.cpp
@@ -1,18 +1,21 @@
-// Copyright (c) 2023, DeepLink.
+// Copyright (c) 2024, DeepLink.
 #include "AscendDeviceActivity.h"
 
 #include <chrono>
-#include <cstdlib>
 #include <cstdio>
+#include <cstdlib>
+#include <dirent.h>
 #include <output_base.h>
+#include <sys/stat.h>
 #include <time_since_epoch.h>
+#include <unistd.h>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
-#include <sys/stat.h>
 
 #include <c10/util/Exception.h>
 
+#include "csrc_dipu/base/environ.hpp"
 #include "csrc_dipu/utils/Log.h"
 
 namespace dipu {
@@ -48,12 +51,61 @@ void AscendDeviceActivity::disableActivities(
 // override pure virtual function, do nothing
 void AscendDeviceActivity::clearActivities() {}
 
+bool AscendDeviceActivity::remove_temp_dump_path_(const std::string& path) {
+  DIR* dir = opendir(path.c_str());
+  if (!dir) {
+    return false;
+  }
+
+  dirent* entry;
+  while ((entry = readdir(dir)) != nullptr) {
+    std::string entry_name = entry->d_name;
+    if (entry_name == "." || entry_name == "..") {
+      continue;
+    }
+
+    std::string entry_path = path + "/" + entry_name;
+    struct stat entry_stat;
+    if (stat(entry_path.c_str(), &entry_stat) == -1) {
+      closedir(dir);
+      return false;
+    }
+
+    if (S_ISDIR(entry_stat.st_mode)) {
+      if (!remove_temp_dump_path_(entry_path)) {
+        closedir(dir);
+        return false;
+      }
+    } else {
+      if (remove(entry_path.c_str()) != 0) {
+        closedir(dir);
+        return false;
+      }
+    }
+  }
+
+  closedir(dir);
+  return rmdir(path.c_str()) == 0;
+}
+
+char* AscendDeviceActivity::generate_temp_dump_path_() {
+  struct stat st;
+  if (stat("./tmp", &st) == -1) {
+    mkdir("./tmp", 0777);
+  }
+  if (stat("./tmp/aclprof", &st) == -1) {
+    mkdir("./tmp/aclprof", 0777);
+  }
+
+  char dump_path_template[] = "./tmp/aclprof/aclprofXXXXXX";
+  return mkdtemp(dump_path_template);
+}
+
 int32_t AscendDeviceActivity::processActivities(
     libkineto::ActivityLogger& logger,
     std::function<const libkineto::ITraceActivity*(int32_t)> linked_activity,
     int64_t start_time, int64_t end_time) {
-
-  // 传递USER_ANNOTAION activity标识dump路径
+  // use USER_ANNOTAION activity to pass dump path to python
   GenericTraceActivity tmp_path;
   tmp_path.activityName = "random_temp_dir:" + current_dump_path_;
   tmp_path.activityType = libkineto::ActivityType::USER_ANNOTATION;
@@ -61,9 +113,12 @@ int32_t AscendDeviceActivity::processActivities(
   tmp_path.endTime = end_time;
   logger.handleGenericActivity(tmp_path);
 
-  std::string temp_path_prefix = "/tmp/aclprof";
-  if (last_dump_path_.compare(0, temp_path_prefix.size(), temp_path_prefix) == 0) {
-    // TODO 删除不再使用的last_dump_path_
+  std::string temp_path_prefix = "./tmp/aclprof";
+  if (last_dump_path_.compare(0, temp_path_prefix.size(), temp_path_prefix) ==
+      0) {
+    if (remove_temp_dump_path_(last_dump_path_) == false) {
+      DIPU_LOGW("remove temp file failed, may need to remove manually");
+    }
   }
 
   return 0;
@@ -79,21 +134,19 @@ void AscendDeviceActivity::startTrace(
 
   last_dump_path_ = current_dump_path_;
 
-  // 创建随机临时路径
-  struct stat st = {0};
-  if (stat("/tmp/aclprof", &st) == -1) {
-    mkdir("/tmp/aclprof", 0777);
-  }
-  char dump_path_template[] = "/tmp/aclprof/aclprofXXXXXX";
-  char* dump_path_cstring = mkdtemp(dump_path_template);
+  char* dump_path_cstring = generate_temp_dump_path_();
+
   if (dump_path_cstring != nullptr) {
-    current_dump_path_ = (std::string)dump_path_cstring;
+    current_dump_path_ = dump_path_cstring;
   } else {
-    DIPU_LOGE("aclprof random dump path generate failed, the export results may be incorrect");
-    current_dump_path_ = "/tmp/aclprof/aclprof_error";
+    DIPU_LOGE(
+        "aclprof random dump path generate failed, the export results may be "
+        "incorrect");
+    current_dump_path_ = "./tmp/aclprof/aclprof_error";
   }
 
-  DIPU_CALLACLRT(aclprofInit(current_dump_path_.c_str(), current_dump_path_.size()));
+  DIPU_CALLACLRT(
+      aclprofInit(current_dump_path_.c_str(), current_dump_path_.size()));
   DIPU_CALLACLRT(aclrtSynchronizeDevice());
 
   int32_t device_index = 0;
@@ -125,7 +178,6 @@ void AscendDeviceActivity::stopTrace(
   enable_ = false;
 }
 
-
 // override pure virtual function, do nothing
 void AscendDeviceActivity::teardownContext() {}
 
@@ -134,9 +186,8 @@ void AscendDeviceActivity::setMaxBufferSize(int32_t size) {}
 
 // NOLINTNEXTLINE(cppcoreguidelines-interfaces-global-init)
 const static int32_t Ascend_device_activity_init = []() {
-  const char* env = std::getenv("FORCE_USE_DIPU_PROFILER");
-  if ((env == nullptr) || (strncmp(env, "false", strlen("false")) == 0) ||
-      (strncmp(env, "False", strlen("False")) == 0)) {
+  if (!dipu::environ::detail::getEnvOrDefault<bool>("FORCE_USE_DIPU_PROFILER",
+                                                    false)) {
     libkineto::device_activity_singleton = &AscendDeviceActivity::instance();
     return 1;
   }

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.h
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.h
@@ -60,7 +60,6 @@ class AscendDeviceActivity : public libkineto::DeviceActivityInterface {
  private:
   AscendDeviceActivity();
   bool remove_temp_dump_path_(const std::string& path);
-  char* generate_temp_dump_path_();
   aclprofConfig* config_ = nullptr;
   bool enable_ = false;
   std::string current_dump_path_;

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.h
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.h
@@ -1,14 +1,13 @@
-// Copyright (c) 2023, DeepLink.
+// Copyright (c) 2024, DeepLink.
 #pragma once
-
-#include <acl/acl.h>
-#include <acl/acl_op.h>
-#include <acl/acl_op_compiler.h>
-#include <acl/acl_prof.h>
 
 #include <DeviceActivityInterface.h>
 #include <GenericTraceActivity.h>
 #include <IActivityProfiler.h>
+#include <acl/acl.h>
+#include <acl/acl_op.h>
+#include <acl/acl_op_compiler.h>
+#include <acl/acl_prof.h>
 #include <array>
 #include <cstdint>
 #include <map>
@@ -60,6 +59,8 @@ class AscendDeviceActivity : public libkineto::DeviceActivityInterface {
 
  private:
   AscendDeviceActivity();
+  bool remove_temp_dump_path_(const std::string& path);
+  char* generate_temp_dump_path_();
   aclprofConfig* config_ = nullptr;
   bool enable_ = false;
   std::string current_dump_path_;

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.h
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2023, DeepLink.
+#pragma once
+
+#include <acl/acl.h>
+#include <acl/acl_op.h>
+#include <acl/acl_op_compiler.h>
+#include <acl/acl_prof.h>
+
+#include <DeviceActivityInterface.h>
+#include <GenericTraceActivity.h>
+#include <IActivityProfiler.h>
+#include <array>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <csrc_dipu/runtime/device/profilerapis.h>
+#include <csrc_dipu/vendor/vendorapi.h>
+
+#include "basecommimpl.hpp"
+
+namespace dipu {
+
+class AscendDeviceActivity : public libkineto::DeviceActivityInterface {
+ public:
+  ~AscendDeviceActivity() override = default;
+  AscendDeviceActivity(const AscendDeviceActivity&) = delete;
+  AscendDeviceActivity& operator=(const AscendDeviceActivity&) = delete;
+
+  // AscendDeviceActivity designed as a singleton
+  static AscendDeviceActivity& instance();
+
+  void pushCorrelationID(
+      uint64_t id,
+      libkineto::DeviceActivityInterface::CorrelationFlowType type) override;
+  void popCorrelationID(
+      libkineto::DeviceActivityInterface::CorrelationFlowType type) override;
+
+  void enableActivities(
+      const std::set<libkineto::ActivityType>& selected_activities) override;
+  void disableActivities(
+      const std::set<libkineto::ActivityType>& selected_activities) override;
+  void clearActivities() override;
+  int32_t processActivities(
+      libkineto::ActivityLogger& logger,
+      std::function<const libkineto::ITraceActivity*(int32_t)> linked_activity,
+      int64_t start_time, int64_t end_time) override;
+
+  void startTrace(
+      const std::set<libkineto::ActivityType>& selected_activities) override;
+  void stopTrace(
+      const std::set<libkineto::ActivityType>& selected_activities) override;
+
+  void teardownContext() override;
+  void setMaxBufferSize(int32_t size) override;
+
+ private:
+  AscendDeviceActivity();
+  aclprofConfig* config_ = nullptr;
+  bool enable_ = false;
+  std::string current_dump_path_;
+  std::string last_dump_path_;
+};
+
+}  // namespace dipu

--- a/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.h
+++ b/dipu/torch_dipu/csrc_dipu/vendor/ascend/AscendDeviceActivity.h
@@ -5,20 +5,9 @@
 #include <GenericTraceActivity.h>
 #include <IActivityProfiler.h>
 #include <acl/acl.h>
-#include <acl/acl_op.h>
-#include <acl/acl_op_compiler.h>
 #include <acl/acl_prof.h>
 #include <array>
-#include <cstdint>
-#include <map>
-#include <memory>
-#include <mutex>
-#include <unordered_map>
-#include <utility>
 #include <vector>
-
-#include <csrc_dipu/runtime/device/profilerapis.h>
-#include <csrc_dipu/vendor/vendorapi.h>
 
 #include "basecommimpl.hpp"
 

--- a/dipu/torch_dipu/profiler/ascend/ascend_profiler_merger.py
+++ b/dipu/torch_dipu/profiler/ascend/ascend_profiler_merger.py
@@ -1,0 +1,213 @@
+import json
+import os
+import subprocess
+from typing import Union, Tuple
+
+class _PathManager:
+    @staticmethod
+    def _remove_directory(path: str) -> None:
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"The path '{path}' does not exist")
+        for root, dirs, files in os.walk(path, topdown=False):
+            for name in files:
+                file_path = os.path.join(root, name)
+                os.remove(file_path)
+            for name in dirs:
+                dir_path = os.path.join(root, name)
+                os.rmdir(dir_path)
+        os.rmdir(path)
+
+    @staticmethod
+    def get_npu_profile_path(tmp_file_path: str) -> str:
+        # 正常情况下，文件夹内有且仅有一个dir
+        for dir in os.listdir(tmp_file_path):
+            return os.path.join(tmp_file_path, dir)
+        return ""
+    
+    @staticmethod
+    def get_msprof_profile_json_path(npu_profile_path: str) -> Union[str, None]:
+        msprof_profile_path = os.path.join(npu_profile_path, 'mindstudio_profiler_output')
+        for data_file in os.listdir(msprof_profile_path):
+            if data_file.startswith('msprof_'):
+                return os.path.join(msprof_profile_path, data_file)
+        return None
+
+    @classmethod
+    def remove_temp_msprof_directory(cls, path: str) -> None:
+        if path.startswith('/tmp/aclprof') == False:
+            raise ValueError("Invalid temp msprof path format")
+        cls._remove_directory(path)
+        
+class _AscendProfilerMerger:
+    def __init__(self, kineto_profile_json_path: str):
+        self._kineto_profile_data = self._load_chrome_trace_json(kineto_profile_json_path)
+        self._msprof_profile_data = []
+
+        # 每一层process对应的process_id
+        self._process_id = {
+            'python3': None,
+            'CANN': None,
+            'Ascend Hardware': None,
+            'Overlap Analysis': None,
+            'HCCL': None,
+            'AI Core Freq': None
+        }
+
+        # 保证python层早于hardware层显示
+        self._python3_sort_idx = 0
+
+        # 保证所有python to kernel的箭头都可以被连上的最小ts_offset
+        self._ts_min_offset = 0.0
+
+        # 整体偏移的process key（硬件层）
+        self._hardware_process_list = ['Ascend Hardware', 'Overlap Analysis', 'HCCL', 'AI Core Freq']
+
+        self._export_path = kineto_profile_json_path
+
+        self._preprocess_kineto_profile_data()
+
+    # 目前，kineto_profile_data是dict类型
+    # msprof_profile_data是list类型
+    @staticmethod
+    def _load_chrome_trace_json(file_path: str) -> Union[dict, list]:
+        with open(file_path, 'r') as file:
+            return json.load(file)
+
+    def _preprocess_kineto_profile_data(self) -> None:
+
+        # 找到并删除C++层传上来的特殊event（代表npu profile路径）
+        temp_path_event_list = []
+        for event in self._kineto_profile_data['traceEvents']:
+            if event['name'] == 'process_name' and self._process_id['python3'] == None:
+                self._process_id['python3'] = event['pid']
+            if 'cat' in event.keys() and event['cat'] == 'user_annotation' and event['name'].startswith('random_temp_dir'):
+                temp_path_event_list.append(event)
+            if event['name'] == 'process_sort_index' and event['pid'] == self._process_id['python3']:
+                self._python3_sort_idx = event['args']['sort_index']
+        self._kineto_profile_data['traceEvents'] = [
+            event for event in self._kineto_profile_data['traceEvents'] if event not in temp_path_event_list]
+
+        npu_temp_path_count = set()
+        for temp_path_event in temp_path_event_list:
+            npu_temp_path = temp_path_event['name'][16:]
+            if npu_temp_path in npu_temp_path_count:
+                continue
+
+            npu_temp_path_count.add(npu_temp_path)
+            # 提取C++层传上来的temp路径
+            npu_profile_path = _PathManager.get_npu_profile_path(npu_temp_path)
+            command = ["msprof", "--export=on", f"--output={npu_profile_path}/."] 
+
+            # 在类初始化前确保了msprof命令存在
+            subprocess.run(command, capture_output=True, text=True)
+            msprof_profile_json_path = _PathManager.get_msprof_profile_json_path(npu_profile_path)
+            if self._msprof_profile_data == []:
+              self._process_id, self._msprof_profile_data = self._filter_msprof_profile_event(self._load_chrome_trace_json(msprof_profile_json_path))
+            else:
+              self._merge_msprof_profile_data(self._load_chrome_trace_json(msprof_profile_json_path))
+
+            # 删除npu profile临时文件
+            _PathManager.remove_temp_msprof_directory(npu_temp_path)
+
+    # 模仿torch_npu，将某些cann层不需要被显示的event过滤掉
+    # 为了提高效率，在过滤的同时统计process_id和process_name之间的关系
+    def _filter_msprof_profile_event(self, input_msprof_data: list) -> Tuple[dict, list]:
+        msprof_process_id = self._process_id
+        filtered_msprof_event_list = []
+        def filter_event_condition(event: dict) -> bool:
+            if event['pid'] != msprof_process_id['CANN']:
+                return False
+            if event['name'].startswith('HostToDevice'):
+                return False
+            if event['name'].startswith('AscendCL'):
+                if event['args']['id'].startswith('acl'):
+                    return False
+            return True
+
+        # 按照msprof排列，process_name event固定在开头位置，因此两个任务可以优化成一次遍历
+        # 若排列顺序发生变化，本部分代码将不再适用，需要拆分成两个遍历
+        for event in input_msprof_data:
+            if event['name'] == 'process_name':
+                for process_name in self._process_id.keys():
+                    if event['args']['name'] == process_name:
+                        msprof_process_id[process_name] = event['pid']
+            elif filter_event_condition(event) == True:
+                continue
+            filtered_msprof_event_list.append(event)
+
+        return msprof_process_id, filtered_msprof_event_list
+    
+    # 将底层产生的多个msprof json文件合并
+    def _merge_msprof_profile_data(self, input_msprof_data: list) -> None:
+        process_id, input_msprof_data = self._filter_msprof_profile_event(input_msprof_data)
+        for event in input_msprof_data:
+            if event['ph'] != 'X' and event['ph'] != 'f' and event['ph'] != 's':
+                continue
+            for key in process_id.keys():
+                if event['pid'] != process_id[key]:
+                    continue
+                event['pid'] = self._process_id[key]
+                self._msprof_profile_data.append(event)
+                break
+    
+    def _calculate_ts_min_offset(self) -> None:
+        flow_start_dict = {}
+        flow_end_dict = {}
+        for event in self._msprof_profile_data:
+            if not event['name'].startswith('HostToDevice'):
+                continue
+            if event['pid'] == self._process_id['CANN']:
+                flow_start_dict[event['id']] = event['ts']
+            elif event['pid'] == self._process_id['Ascend Hardware']:
+                flow_end_dict[event['id']] = event['ts']
+
+        for key, value in flow_start_dict.items():
+            if key in flow_end_dict.keys():
+                current_ts_offset_need = float(value) - float(flow_end_dict[key])
+                self._ts_min_offset = max(self._ts_min_offset, current_ts_offset_need + 1)
+    
+    def _add_ts_offset_to_hardware(self) -> None:
+        for event in self._msprof_profile_data:
+            if 'ts' not in event.keys():
+                continue
+            for hardware_process_name in self._hardware_process_list:
+                if event['pid'] == self._process_id[hardware_process_name]:
+                    event['ts'] = str(float(event['ts']) + self._ts_min_offset)  
+                    break
+    
+    def _merge_msprof_to_kineto(self) -> None:
+        for event in self._kineto_profile_data['traceEvents']:
+            if event['name'] == 'process_name':
+                self._process_id['python3'] = event['pid']
+                break
+        
+        for event in self._msprof_profile_data:
+            if event['pid'] == self._process_id['CANN']:
+                event['pid'] = self._process_id['python3']
+            if event['name'] == 'process_sort_index':
+                event['args']['sort_index'] += self._python3_sort_idx
+            self._kineto_profile_data['traceEvents'].append(event)
+        
+    def _export_to_json(self) -> None:
+        with open(self._export_path, 'w') as json_file:
+            json.dump(self._kineto_profile_data, json_file, indent=4)
+    
+    def start_merge(self) -> None:
+        self._calculate_ts_min_offset()
+        self._add_ts_offset_to_hardware()
+        self._merge_msprof_to_kineto()
+        self._export_to_json()
+
+def _command_exists(command) -> bool:
+    try:
+        subprocess.run(['which', command], check=True, capture_output=True)
+        return True
+    except subprocess.CalledProcessError:
+        print("msprof command not exist, merge process will be canceled")
+        return False
+    
+def merge_kineto_and_msprof_profile_data(path: str) -> None:
+    if not _command_exists('msprof'):
+        return
+    merger = _AscendProfilerMerger(path)
+    merger.start_merge()

--- a/dipu/torch_dipu/profiler/ascend/ascend_profiler_merger.py
+++ b/dipu/torch_dipu/profiler/ascend/ascend_profiler_merger.py
@@ -1,7 +1,8 @@
 import json
 import os
 import subprocess
-from typing import Union, Tuple
+from typing import Union
+
 
 class _PathManager:
     @staticmethod
@@ -19,195 +20,231 @@ class _PathManager:
 
     @staticmethod
     def get_npu_profile_path(tmp_file_path: str) -> str:
-        # 正常情况下，文件夹内有且仅有一个dir
+        # in the correct case, there is only one directory in the folder
         for dir in os.listdir(tmp_file_path):
             return os.path.join(tmp_file_path, dir)
         return ""
-    
+
     @staticmethod
     def get_msprof_profile_json_path(npu_profile_path: str) -> Union[str, None]:
-        msprof_profile_path = os.path.join(npu_profile_path, 'mindstudio_profiler_output')
+        msprof_profile_path = os.path.join(
+            npu_profile_path, "mindstudio_profiler_output"
+        )
         for data_file in os.listdir(msprof_profile_path):
-            if data_file.startswith('msprof_'):
+            if data_file.startswith("msprof_"):
                 return os.path.join(msprof_profile_path, data_file)
         return None
 
     @classmethod
     def remove_temp_msprof_directory(cls, path: str) -> None:
-        if path.startswith('/tmp/aclprof') == False:
+        if "/tmp/aclprof" not in path:
             raise ValueError("Invalid temp msprof path format")
         cls._remove_directory(path)
-        
+
+
 class _AscendProfilerMerger:
     def __init__(self, kineto_profile_json_path: str):
-        self._kineto_profile_data = self._load_chrome_trace_json(kineto_profile_json_path)
+        self._kineto_profile_data = self._load_chrome_trace_json(
+            kineto_profile_json_path
+        )
         self._msprof_profile_data = []
-
-        # 每一层process对应的process_id
         self._process_id = {
-            'python3': None,
-            'CANN': None,
-            'Ascend Hardware': None,
-            'Overlap Analysis': None,
-            'HCCL': None,
-            'AI Core Freq': None
+            "python3": None,
+            "CANN": None,
+            "Ascend Hardware": None,
+            "Overlap Analysis": None,
+            "HCCL": None,
+            "AI Core Freq": None,
         }
 
-        # 保证python层早于hardware层显示
+        # this sort_idx is used to make sure python3 is above hardware event
         self._python3_sort_idx = 0
 
-        # 保证所有python to kernel的箭头都可以被连上的最小ts_offset
+        # time diff between realtime and monotonic_raw
+        self._acl_time_diff = 0
+        self._torch_time_diff = 0
+
+        # the minimum timestamp_offset that ensure every flow event could be displayed normally
         self._ts_min_offset = 0.0
 
-        # 整体偏移的process key（硬件层）
-        self._hardware_process_list = ['Ascend Hardware', 'Overlap Analysis', 'HCCL', 'AI Core Freq']
+        self._hardware_process_list = [
+            "Ascend Hardware",
+            "Overlap Analysis",
+            "HCCL",
+            "AI Core Freq",
+        ]
 
         self._export_path = kineto_profile_json_path
 
         self._preprocess_kineto_profile_data()
 
-    # 目前，kineto_profile_data是dict类型
-    # msprof_profile_data是list类型
+    # in the correct case, kineto_profile_data is a dict
+    # and msprof_profile_data is a list
     @staticmethod
     def _load_chrome_trace_json(file_path: str) -> Union[dict, list]:
-        with open(file_path, 'r') as file:
+        with open(file_path, "r") as file:
             return json.load(file)
 
     def _preprocess_kineto_profile_data(self) -> None:
 
-        # 找到并删除C++层传上来的特殊event（代表npu profile路径）
-        temp_path_event_list = []
-        for event in self._kineto_profile_data['traceEvents']:
-            if event['name'] == 'process_name' and self._process_id['python3'] == None:
-                self._process_id['python3'] = event['pid']
-            if 'cat' in event.keys() and event['cat'] == 'user_annotation' and event['name'].startswith('random_temp_dir'):
-                temp_path_event_list.append(event)
-            if event['name'] == 'process_sort_index' and event['pid'] == self._process_id['python3']:
-                self._python3_sort_idx = event['args']['sort_index']
-        self._kineto_profile_data['traceEvents'] = [
-            event for event in self._kineto_profile_data['traceEvents'] if event not in temp_path_event_list]
+        # find and delete special events passed by cpp which represent for npu profile dump path
+        # in the correct case, one msprof.json file corresponds to one Kineto.json file.
+        temp_path_event = {}
+        torch_time_diff_event = {}
 
-        npu_temp_path_count = set()
-        for temp_path_event in temp_path_event_list:
-            npu_temp_path = temp_path_event['name'][16:]
-            if npu_temp_path in npu_temp_path_count:
-                continue
+        temp_path_event_begin_name = "random_temp_dir:"
+        torch_time_diff_event_begin_name = "torch_time_diff:"
 
-            npu_temp_path_count.add(npu_temp_path)
-            # 提取C++层传上来的temp路径
-            npu_profile_path = _PathManager.get_npu_profile_path(npu_temp_path)
-            command = ["msprof", "--export=on", f"--output={npu_profile_path}/."] 
+        # get each process's name, id and sort_index
+        # get special event that for temp_path and torch_time_diff
+        for event in self._kineto_profile_data["traceEvents"]:
+            if event["name"] == "process_name" and self._process_id["python3"] == None:
+                self._process_id["python3"] = event["pid"]
+            if (
+                event["name"] == "process_sort_index"
+                and event["pid"] == self._process_id["python3"]
+            ):
+                self._python3_sort_idx = event["args"]["sort_index"]
+            if (
+                "cat" in event.keys()
+                and event["cat"] == "user_annotation"
+                and event["name"].startswith(temp_path_event_begin_name)
+            ):
+                temp_path_event = event
+            elif event["name"].startswith(torch_time_diff_event_begin_name):
+                torch_time_diff_event = event
+        self._kineto_profile_data["traceEvents"].remove(temp_path_event)
+        self._kineto_profile_data["traceEvents"].remove(torch_time_diff_event)
 
-            # 在类初始化前确保了msprof命令存在
-            subprocess.run(command, capture_output=True, text=True)
-            msprof_profile_json_path = _PathManager.get_msprof_profile_json_path(npu_profile_path)
-            if self._msprof_profile_data == []:
-              self._process_id, self._msprof_profile_data = self._filter_msprof_profile_event(self._load_chrome_trace_json(msprof_profile_json_path))
-            else:
-              self._merge_msprof_profile_data(self._load_chrome_trace_json(msprof_profile_json_path))
+        npu_temp_path = temp_path_event["name"][len(temp_path_event_begin_name) :]
+        self._torch_time_diff = int(
+            torch_time_diff_event["name"][len(torch_time_diff_event_begin_name) :]
+        )
+        npu_profile_path = _PathManager.get_npu_profile_path(npu_temp_path)
+        command = ["msprof", "--export=on", f"--output={npu_profile_path}/."]
 
-            # 删除npu profile临时文件
-            _PathManager.remove_temp_msprof_directory(npu_temp_path)
+        # the existence of the msprof command is ensured before class initialization
+        subprocess.run(command, capture_output=True, text=True)
+        msprof_profile_json_path = _PathManager.get_msprof_profile_json_path(
+            npu_profile_path
+        )
+        self._filter_msprof_profile_event(
+            self._load_chrome_trace_json(msprof_profile_json_path)
+        )
 
-    # 模仿torch_npu，将某些cann层不需要被显示的event过滤掉
-    # 为了提高效率，在过滤的同时统计process_id和process_name之间的关系
-    def _filter_msprof_profile_event(self, input_msprof_data: list) -> Tuple[dict, list]:
-        msprof_process_id = self._process_id
-        filtered_msprof_event_list = []
+        # get acl_time_diff
+        msprof_end_info_path = os.path.join(npu_profile_path, "host/end_info")
+        with open(msprof_end_info_path, "r") as file:
+            end_info = json.load(file)
+        self._acl_time_diff = int(end_info["collectionTimeEnd"]) * 1000 - int(
+            end_info["clockMonotonicRaw"]
+        )
+
+        _PathManager.remove_temp_msprof_directory(npu_temp_path)
+
+    # imitate torch_npu to filter out certain CANN layers' events that are not needed to be displayed
+    # to improve efficiency, also count the relationship between process_id and process_name while filtering
+    def _filter_msprof_profile_event(self, input_msprof_data: list) -> None:
         def filter_event_condition(event: dict) -> bool:
-            if event['pid'] != msprof_process_id['CANN']:
+            if event["pid"] != self._process_id["CANN"]:
                 return False
-            if event['name'].startswith('HostToDevice'):
+            if event["name"].startswith("HostToDevice"):
                 return False
-            if event['name'].startswith('AscendCL'):
-                if event['args']['id'].startswith('acl'):
+            if event["name"].startswith("AscendCL"):
+                if event["args"]["id"].startswith("acl"):
                     return False
             return True
 
-        # 按照msprof排列，process_name event固定在开头位置，因此两个任务可以优化成一次遍历
-        # 若排列顺序发生变化，本部分代码将不再适用，需要拆分成两个遍历
+        # the event arrangement in the msprof JSON file has a special property,
+        # that the "process_name" event is fixed at the beginning,
+        # so two tasks can be optimized by iterating once
+        # if the arrangement changes,
+        # the following code will no longer be applicable,
+        # and needs to be split into two iteration
         for event in input_msprof_data:
-            if event['name'] == 'process_name':
+            if event["name"] == "process_name":
                 for process_name in self._process_id.keys():
-                    if event['args']['name'] == process_name:
-                        msprof_process_id[process_name] = event['pid']
+                    if event["args"]["name"] == process_name:
+                        self._process_id[process_name] = event["pid"]
             elif filter_event_condition(event) == True:
                 continue
-            filtered_msprof_event_list.append(event)
+            self._msprof_profile_data.append(event)
 
-        return msprof_process_id, filtered_msprof_event_list
-    
-    # 将底层产生的多个msprof json文件合并
-    def _merge_msprof_profile_data(self, input_msprof_data: list) -> None:
-        process_id, input_msprof_data = self._filter_msprof_profile_event(input_msprof_data)
-        for event in input_msprof_data:
-            if event['ph'] != 'X' and event['ph'] != 'f' and event['ph'] != 's':
-                continue
-            for key in process_id.keys():
-                if event['pid'] != process_id[key]:
-                    continue
-                event['pid'] = self._process_id[key]
-                self._msprof_profile_data.append(event)
-                break
-    
+    # make sure that every flow event's begin time is smaller than end time
     def _calculate_ts_min_offset(self) -> None:
         flow_start_dict = {}
         flow_end_dict = {}
         for event in self._msprof_profile_data:
-            if not event['name'].startswith('HostToDevice'):
+            if not event["name"].startswith("HostToDevice"):
                 continue
-            if event['pid'] == self._process_id['CANN']:
-                flow_start_dict[event['id']] = event['ts']
-            elif event['pid'] == self._process_id['Ascend Hardware']:
-                flow_end_dict[event['id']] = event['ts']
+            if event["pid"] == self._process_id["CANN"]:
+                flow_start_dict[event["id"]] = event["ts"]
+            elif event["pid"] == self._process_id["Ascend Hardware"]:
+                flow_end_dict[event["id"]] = event["ts"]
 
-        for key, value in flow_start_dict.items():
+        for key in flow_start_dict.keys():
             if key in flow_end_dict.keys():
-                current_ts_offset_need = float(value) - float(flow_end_dict[key])
-                self._ts_min_offset = max(self._ts_min_offset, current_ts_offset_need + 1)
-    
+
+                # hardware offset needed for current event
+                # for example if end time is 2 and start time is 4
+                # we need to offset event in hardware (start time - end time) + 1
+                # and for all results, we need to get the maximal value among them
+                current_ts_offset_need = float(flow_start_dict[key]) - float(
+                    flow_end_dict[key]
+                )
+                self._ts_min_offset = max(
+                    self._ts_min_offset, current_ts_offset_need + 1
+                )
+
     def _add_ts_offset_to_hardware(self) -> None:
         for event in self._msprof_profile_data:
-            if 'ts' not in event.keys():
+            if "ts" not in event.keys():
                 continue
             for hardware_process_name in self._hardware_process_list:
-                if event['pid'] == self._process_id[hardware_process_name]:
-                    event['ts'] = str(float(event['ts']) + self._ts_min_offset)  
+                if event["pid"] == self._process_id[hardware_process_name]:
+                    event["ts"] = str(float(event["ts"]) + self._ts_min_offset)
                     break
-    
+
     def _merge_msprof_to_kineto(self) -> None:
-        for event in self._kineto_profile_data['traceEvents']:
-            if event['name'] == 'process_name':
-                self._process_id['python3'] = event['pid']
+        for event in self._kineto_profile_data["traceEvents"]:
+            if event["name"] == "process_name":
+                self._process_id["python3"] = event["pid"]
                 break
-        
+
+        # to make sure cann timestamp align to kineto timestamp
+        local_time_diff = (self._torch_time_diff - self._acl_time_diff) / 1000
+
         for event in self._msprof_profile_data:
-            if event['pid'] == self._process_id['CANN']:
-                event['pid'] = self._process_id['python3']
-            if event['name'] == 'process_sort_index':
-                event['args']['sort_index'] += self._python3_sort_idx
-            self._kineto_profile_data['traceEvents'].append(event)
-        
+            if event["pid"] == self._process_id["CANN"]:
+                event["pid"] = self._process_id["python3"]
+            if event["name"] == "process_sort_index":
+                event["args"]["sort_index"] += self._python3_sort_idx
+            if "ts" in event.keys():
+                event["ts"] = str(float(event["ts"]) + local_time_diff)
+            self._kineto_profile_data["traceEvents"].append(event)
+
     def _export_to_json(self) -> None:
-        with open(self._export_path, 'w') as json_file:
+        with open(self._export_path, "w") as json_file:
             json.dump(self._kineto_profile_data, json_file, indent=4)
-    
+
     def start_merge(self) -> None:
         self._calculate_ts_min_offset()
         self._add_ts_offset_to_hardware()
         self._merge_msprof_to_kineto()
         self._export_to_json()
 
+
 def _command_exists(command) -> bool:
     try:
-        subprocess.run(['which', command], check=True, capture_output=True)
+        subprocess.run(["which", command], check=True, capture_output=True)
         return True
     except subprocess.CalledProcessError:
         print("msprof command not exist, merge process will be canceled")
         return False
-    
+
+
 def merge_kineto_and_msprof_profile_data(path: str) -> None:
-    if not _command_exists('msprof'):
+    if not _command_exists("msprof"):
         return
     merger = _AscendProfilerMerger(path)
     merger.start_merge()

--- a/dipu/torch_dipu/profiler/profiler.py
+++ b/dipu/torch_dipu/profiler/profiler.py
@@ -508,15 +508,26 @@ def apply_profiler_patch():
     if _C.dipu_vendor == "NPU":
         _apply_ascend_profiler_patch()
 
+
 def _apply_ascend_profiler_patch():
-    from torch_dipu.profiler.ascend.ascend_profiler_merger import merge_kineto_and_msprof_profile_data
-    torch.autograd.profiler.profile.export_chrome_trace_backup = torch.autograd.profiler.profile.export_chrome_trace
+    from torch_dipu.profiler.ascend.ascend_profiler_merger import (
+        merge_kineto_and_msprof_profile_data,
+    )
+
+    torch.autograd.profiler.profile.export_chrome_trace_backup = (
+        torch.autograd.profiler.profile.export_chrome_trace
+    )
 
     def export_chrome_trace_with_merger(self, path: str):
         self.export_chrome_trace_backup(path)
         merge_kineto_and_msprof_profile_data(path)
 
-    setattr(torch.autograd.profiler.profile, "export_chrome_trace", export_chrome_trace_with_merger)
+    setattr(
+        torch.autograd.profiler.profile,
+        "export_chrome_trace",
+        export_chrome_trace_with_merger,
+    )
+
 
 class NativeProfile(object):
     def __init__(

--- a/dipu/torch_dipu/profiler/profiler.py
+++ b/dipu/torch_dipu/profiler/profiler.py
@@ -505,6 +505,18 @@ def apply_profiler_patch():
     setattr(torch.autograd.profiler_util, "_build_table", dipu_build_table)
     torch.autograd.profiler.profile = TorchProfile
 
+    if _C.dipu_vendor == "NPU":
+        _apply_ascend_profiler_patch()
+
+def _apply_ascend_profiler_patch():
+    from torch_dipu.profiler.ascend.ascend_profiler_merger import merge_kineto_and_msprof_profile_data
+    torch.autograd.profiler.profile.export_chrome_trace_backup = torch.autograd.profiler.profile.export_chrome_trace
+
+    def export_chrome_trace_with_merger(self, path: str):
+        self.export_chrome_trace_backup(path)
+        merge_kineto_and_msprof_profile_data(path)
+
+    setattr(torch.autograd.profiler.profile, "export_chrome_trace", export_chrome_trace_with_merger)
 
 class NativeProfile(object):
     def __init__(


### PR DESCRIPTION
# DIPU ascend profiler对齐

## Summary
将DIPU ascend profiler和torch profiler对齐

## 实现思路
- cpp层通过实现libkineto接口，调用aclprof api，在临时路径生成包含硬件统计信息的ascend PROF文件，并通过libkineto将路径传递到python层
- python层mock了torch profile中的export_chrome_trace方法，加入msprof工具解析、chrome_json合并操作

## 测试
- 已在910机器上验证过单机单卡和单机多卡

## 示例用法和结果
```py
output_path = './example.json'
input = torch.randn(2, 3).cuda()
with profile(
    activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
    with_stack=True,
    schedule=torch.profiler.schedule(wait=0, warmup=0, active=2, repeat=2)
) as prof:
    for i in range(10):
      y = fn(input)
      z = y + y    
      prof.step()
prof.export_chrome_trace(output_path)
```

![image](https://github.com/user-attachments/assets/b1b4a725-1f59-4021-bd86-fd6d860a9f08)


