### PR TITLE
fix(dipu,droplet): clear error after malloc failed (no mem)

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/vendor/droplet/deviceimpl.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/droplet/deviceimpl.cpp
@@ -163,6 +163,7 @@ OpStatus mallocDevice(void** p, size_t nbytes, bool throwExcepion) {
       ::tangGetLastError(); /* reset internal error state*/
       throw std::runtime_error("alloc failed in dipu");
     } else if (r == ::tangErrorMemoryAllocation) {
+      ::tangGetLastError();
       return OpStatus::ERR_NOMEM;
     } else {
       return OpStatus::ERR_UNKNOWN;


### PR DESCRIPTION
allocator 随后会尝试释放一些 block 再 malloc，如果不清理错误，之后的调用全都会错误