### PR TITLE
fix async bug on muxi

### DIFF
--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
@@ -412,7 +412,7 @@ and to use muxi native cpu empty op to bypass this issue. see the doc below
 written by guochun1 for detail.
 https://aicarrier.feishu.cn/wiki/PXdYwcsjii9TJZk5AR1cG2bxnFd
 
-Warnning: Need check if this bypass works when using dipu + torch_cpu which not
+Warnning: Need check if this bypass works/needed when using dipu + torch_cpu which not
 contains 'mx' pin mem/cpu-empty op.
 TODO: fandaoyi
 **/

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
@@ -407,12 +407,13 @@ DIPU_LIBRARY_IMPL(aten, DIPU_DEVICE_TYPE_MACRO, m) {
 
 /**
 when test EasyLLM using dipu + muxi pytorch, some mem related error happened
-(Invalid Address). seems dipu's cpu copy op or pin mem empty op has uncertain
-problems. so temporarily use this macro to disable dipu's related op and to use
-muxi native cpu empty op to bypass this issue.
+(Invalid Address). so temporarily use this macro to disable dipu's related op
+and to use muxi native cpu empty op to bypass this issue. see the doc below
+written by guochun1 for detail.
+https://aicarrier.feishu.cn/wiki/PXdYwcsjii9TJZk5AR1cG2bxnFd
 
-Warnning: This bypass not work if using dipu + torch_cpu which not contains
-'mx' pin mem/cpu-empty op.
+Warnning: Need check if this bypass works when using dipu + torch_cpu which not
+contains 'mx' pin mem/cpu-empty op.
 TODO: fandaoyi
 **/
 #if !DIPU_VENDOR_NAME_MUXI

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
@@ -405,6 +405,8 @@ DIPU_LIBRARY_IMPL(aten, DIPU_DEVICE_TYPE_MACRO, m) {
   m.impl("record_stream", TORCH_FN(wrapper_DIPU__record_stream));
 }
 
+#if !DIPU_VENDOR_NAME_MUXI
+
 DIPU_LIBRARY_IMPL(aten, BackendSelect, m) {
   c10::WarningUtils::WarningHandlerGuard guard(dipu::getIgnoreHandler());
   m.impl(TORCH_SELECTIVE_NAME("aten::is_pinned"),
@@ -420,5 +422,7 @@ DIPU_LIBRARY_IMPL(aten, CPU, m) {
   m.impl("empty.memory_format", TORCH_FN(wrapper_CPU_empty_memory_format));
   m.impl("empty_strided", TORCH_FN(wrapper_CPU_empty_strided));
 }
+
+#endif
 
 }  // end namespace at

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
@@ -412,8 +412,8 @@ and to use muxi native cpu empty op to bypass this issue. see the doc below
 written by guochun1 for detail.
 https://aicarrier.feishu.cn/wiki/PXdYwcsjii9TJZk5AR1cG2bxnFd
 
-Warnning: Need check if this bypass works/needed when using dipu + torch_cpu which not
-contains 'mx' pin mem/cpu-empty op.
+Warnning: Need check if this bypass works/needed when using dipu + torch_cpu
+which not contains 'mx' pin mem/cpu-empty op.
 TODO: fandaoyi
 **/
 #if !DIPU_VENDOR_NAME_MUXI

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
@@ -412,7 +412,7 @@ problems. so temporarily use this macro to disable dipu's related op and to use
 muxi native cpu empty op to bypass this issue.
 
 Warnning: This bypass not work if using dipu + torch_cpu which not contains
-'mx' device pin mem op.
+'mx' pin mem/cpu-empty op.
 TODO: fandaoyi
 **/
 #if !DIPU_VENDOR_NAME_MUXI

--- a/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
+++ b/dipu/torch_dipu/csrc_dipu/aten/RegisterDIPU.cpp
@@ -405,6 +405,16 @@ DIPU_LIBRARY_IMPL(aten, DIPU_DEVICE_TYPE_MACRO, m) {
   m.impl("record_stream", TORCH_FN(wrapper_DIPU__record_stream));
 }
 
+/**
+when test EasyLLM using dipu + muxi pytorch, some mem related error happened
+(Invalid Address). seems dipu's cpu copy op or pin mem empty op has uncertain
+problems. so temporarily use this macro to disable dipu's related op and to use
+muxi native cpu empty op to bypass this issue.
+
+Warnning: This bypass not work if using dipu + torch_cpu which not contains
+'mx' device pin mem op.
+TODO: fandaoyi
+**/
 #if !DIPU_VENDOR_NAME_MUXI
 
 DIPU_LIBRARY_IMPL(aten, BackendSelect, m) {

--- a/dipu/torch_dipu/csrc_dipu/vendor/cuda/CUDACopyInplace.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/cuda/CUDACopyInplace.cpp
@@ -26,8 +26,7 @@ class CUDACopyInplace : public DIPUCopyInpOnDIOPI {
       non_blocking = true;
     }
 
-// Temporarily use synchronous copy on mx, see comment near RegisterDIPU.cpp
-// 'BackendSelect'
+// use synchronous copy on mx, see comment near RegisterDIPU.cpp 'BackendSelect'
 #if DIPU_VENDOR_NAME_MUXI
     if (info.copyType_ == DIPUCopyType::D2H ||
         info.copyType_ == DIPUCopyType::H2D) {

--- a/dipu/torch_dipu/csrc_dipu/vendor/cuda/CUDACopyInplace.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/cuda/CUDACopyInplace.cpp
@@ -26,6 +26,13 @@ class CUDACopyInplace : public DIPUCopyInpOnDIOPI {
       non_blocking = true;
     }
 
+#if DIPU_VENDOR_NAME_MUXI
+    if (info.copyType_ == DIPUCopyType::D2H ||
+        info.copyType_ == DIPUCopyType::H2D) {
+      non_blocking = false;
+    }
+#endif
+
     // Exit early if dst and src are views of the same data
     if ((dst.is_alias_of(src) && dst.storage_offset() == src.storage_offset() &&
          info.sameStride_ && info.sameDtype_)) {

--- a/dipu/torch_dipu/csrc_dipu/vendor/cuda/CUDACopyInplace.cpp
+++ b/dipu/torch_dipu/csrc_dipu/vendor/cuda/CUDACopyInplace.cpp
@@ -26,6 +26,8 @@ class CUDACopyInplace : public DIPUCopyInpOnDIOPI {
       non_blocking = true;
     }
 
+// Temporarily use synchronous copy on mx, see comment near RegisterDIPU.cpp
+// 'BackendSelect'
 #if DIPU_VENDOR_NAME_MUXI
     if (info.copyType_ == DIPUCopyType::D2H ||
         info.copyType_ == DIPUCopyType::H2D) {


### PR DESCRIPTION
背景：沐熙设备上异步模式下跑模型时报错，只能同步模式下跑模型。
沐熙cat kernel里面分配了pin_memory 的tensor,并且用了copy算子。如果用了DIPU的allocator分配的pin_memory tensor,再用backend 为CUDA的copy，则不能正确处理tensor的生命周期，导致kernel异步计算时pin_memory的数据被修改（分给了其他tensor）,导致异步运行时报错，同步时没问题
 DIPU_HOST_MEMCACHING_ALGORITHM=RAW 时该问题消失
详细记录：
https://aicarrier.feishu.cn/wiki/PXdYwcsjii9TJZk5AR1cG2bxnFd