### PR TITLE
fix ascend profiler timeline precision issue

### DIFF
--- a/dipu/torch_dipu/profiler/ascend/ascend_profiler_merger.py
+++ b/dipu/torch_dipu/profiler/ascend/ascend_profiler_merger.py
@@ -214,7 +214,7 @@ class _AscendProfilerMerger:
         # msprof_cann_x_event is sorted by timestamp beforehand,
         # and what we need to do is binary search for the event whose time interval contain this timestamp
         # and move start flow event HostToDevice's timestamp to the cann event's begin timestamp
-        def find_wrap_acl_event(ts: Decimal) -> Decimal:
+        def find_wrap_acl_event(ts: float) -> float:
             if len(self._msprof_cann_x_event) == 0:
                 return ts
             l = 0
@@ -240,7 +240,7 @@ class _AscendProfilerMerger:
             if not event["name"].startswith("HostToDevice"):
                 continue
             if event["pid"] == self._process_id["CANN"]:
-                event["ts"] = str(find_wrap_acl_event(Decimal(event["ts"])))
+                event["ts"] = find_wrap_acl_event(float(event["ts"]))
                 flow_start_dict[event["id"]] = event["ts"]
             elif event["pid"] == self._process_id["Ascend Hardware"]:
                 flow_end_dict[event["id"]] = event["ts"]
@@ -261,13 +261,12 @@ class _AscendProfilerMerger:
                 ts_min_offset_need = max(ts_min_offset_need, current_ts_offset_need + 1)
         if ts_min_offset_need == 0:
             return
-        ts_min_offset_need = Decimal(ts_min_offset_need)
         for event in self._msprof_profile_data:
             if "ts" not in event.keys():
                 continue
             for hardware_process_name in self._hardware_process_list:
                 if event["pid"] == self._process_id[hardware_process_name]:
-                    event["ts"] = str(Decimal(event["ts"]) + ts_min_offset_need)
+                    event["ts"] = str(float(event["ts"]) + ts_min_offset_need)
                     break
 
     def _merge_msprof_to_kineto(self) -> None:

--- a/dipu/torch_dipu/profiler/ascend/ascend_profiler_merger.py
+++ b/dipu/torch_dipu/profiler/ascend/ascend_profiler_merger.py
@@ -214,7 +214,7 @@ class _AscendProfilerMerger:
         # msprof_cann_x_event is sorted by timestamp beforehand,
         # and what we need to do is binary search for the event whose time interval contain this timestamp
         # and move start flow event HostToDevice's timestamp to the cann event's begin timestamp
-        def find_wrap_acl_event(ts: float) -> float:
+        def find_wrap_acl_event(ts: float) -> Union[float, Decimal]:
             if len(self._msprof_cann_x_event) == 0:
                 return ts
             l = 0


### PR DESCRIPTION
<img width="597" alt="image" src="https://github.com/user-attachments/assets/f53f8d55-5f8b-4834-90c9-de898dd93303">

在应用中发现ascend hardware event会出现重叠的错位情况

经问题定位，该问题是因为在做时间轴平移的时候，python float转换以及运算造成的精度损失

现将时间轴平移float相关计算转化成decimal

因考虑到decimal计算速度较慢，同时未发现剩余float计算对timeline结果的影响，因此只修改了关键部分的float计算。